### PR TITLE
Eligibility Fix

### DIFF
--- a/FusionIIIT/applications/iwdModuleV2/views.py
+++ b/FusionIIIT/applications/iwdModuleV2/views.py
@@ -32,8 +32,8 @@ theTurnOfExtension = 0
 
 def dashboard(request):
     eligible = False
-    userObj = User.objects.get(id=request.user.id)
-    userDesignationObjects = HoldsDesignation.objects.filter(working=userObj)
+    userObj = request.user
+    userDesignationObjects = HoldsDesignation.objects.filter(user=userObj)
     for p in userDesignationObjects:
         if p.designation.name == 'Admin IWD':
             eligible = True


### PR DESCRIPTION
The fix given here to filter by user and not working is against the comments written in HoldsDesignation Table models.py. It clearly says that eligibility must be matched through working column. We have done as a matter to speed up the review process, but technically then, it raises question on the comments written there,