### PR TITLE
Fixed syntax error in various modules under FusionIIIT

### DIFF
--- a/FusionIIIT/applications/counselling_cell/apps.py
+++ b/FusionIIIT/applications/counselling_cell/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class CounsellingCellConfig(AppConfig):
-    name = 'counselling_cell'
+    name = 'applications.counselling_cell'

--- a/FusionIIIT/applications/establishment/apps.py
+++ b/FusionIIIT/applications/establishment/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class EstablishmentConfig(AppConfig):
-    name = 'establishment'
+    name = 'applications.establishment'

--- a/FusionIIIT/applications/estate_module/apps.py
+++ b/FusionIIIT/applications/estate_module/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class EstateModuleConfig(AppConfig):
-    name = 'estate_module'
+    name = 'applications.estate_module'

--- a/FusionIIIT/applications/income_expenditure/apps.py
+++ b/FusionIIIT/applications/income_expenditure/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class IncomeExpenditureConfig(AppConfig):
-    name = 'income_expenditure'
+    name = 'applications.income_expenditure'

--- a/FusionIIIT/applications/iwdModuleV2/apps.py
+++ b/FusionIIIT/applications/iwdModuleV2/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class Iwdmodulev2Config(AppConfig):
-    name = 'iwdModuleV2'
+    name = 'applications.iwdModuleV2'

--- a/FusionIIIT/applications/notifications_extension/apps.py
+++ b/FusionIIIT/applications/notifications_extension/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class NotificationsExtensionConfig(AppConfig):
-    name = 'notifications_extension'
+    name = 'applications.notifications_extension'

--- a/FusionIIIT/applications/programme_curriculum/apps.py
+++ b/FusionIIIT/applications/programme_curriculum/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class ProgrammeCurriculumConfig(AppConfig):
-    name = 'programme_curriculum'
+    name = 'applications.programme_curriculum'

--- a/FusionIIIT/applications/ps1/apps.py
+++ b/FusionIIIT/applications/ps1/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class Ps1Config(AppConfig):
-    name = 'ps1'
+    name = 'applications.ps1'

--- a/FusionIIIT/applications/recruitment/apps.py
+++ b/FusionIIIT/applications/recruitment/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class RecruitmentConfig(AppConfig):
-    name = 'recruitment'
+    name = 'applications.recruitment'

--- a/FusionIIIT/applications/research_procedures/apps.py
+++ b/FusionIIIT/applications/research_procedures/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class ResearchProceduresConfig(AppConfig):
-     name = 'research_procedures'
+     name = 'applications.research_procedures'

--- a/FusionIIIT/applications/scholarships/views.py
+++ b/FusionIIIT/applications/scholarships/views.py
@@ -1042,11 +1042,17 @@ def sendStudentRenderRequest(request, additionalParams={}):
                     update_con_flag = True
         else:
             if dates.award == "Merit-cum-Means Scholarship" and dates.batch == str(request.user.extrainfo.student)[0:4]:
-                x = Notification.objects.select_related('student_id','release_id').get(
-                    student_id=request.user.extrainfo.id, release_id=dates.id).delete()
+                try:
+                    x = Notification.objects.select_related('student_id','release_id').get(
+                        student_id=request.user.extrainfo.id, release_id=dates.id).delete()
+                except:
+                    pass
             elif dates.award == 'Convocation Medals' and dates.batch == str(request.user.extrainfo.student)[0:4]:
-                x = Notification.objects.select_related('student_id','release_id').get(
-                    student_id=request.user.extrainfo.id, release_id=dates.id).delete()
+                try:
+                    x = Notification.objects.select_related('student_id','release_id').get(
+                        student_id=request.user.extrainfo.id, release_id=dates.id).delete()
+                except:
+                    pass
 
     x = Notification.objects.select_related('student_id','release_id').filter(student_id=request.user.extrainfo.id).order_by('-release_id__date_time')
     show_mcm_flag = False


### PR DESCRIPTION
Group No. 21 (2021-2022)

Issue No. **569**
**Resolved**

There were various modules where the apps.py file didn't contain 'applications' keyword causing error while setting up the codebase in MacOS.

**Before the Commit**
```class EstablishmentConfig(AppConfig):
    name = 'establishment'
```
**After the Commit**
```class EstablishmentConfig(AppConfig):
    name = 'applications.establishment'
```
Issue No. **544**
**Resolved**

The scholarship portal wasn't loading at all due to some exception while dealing with database.
