### PR TITLE
fixed minor typos on acadadmin 

### DIFF
--- a/FusionIIIT/templates/academic_procedures/studentlist.html
+++ b/FusionIIIT/templates/academic_procedures/studentlist.html
@@ -34,7 +34,7 @@
 
 <div class="ui pointing secondary menu">
   <a class="active item" data-tab="verify_course">
-  Verify Courses for Semester {{ date.semflag }} : {{ date.year }}
+  Verify Student Registration for Semester {{ date.semflag }} : {{ date.year }}
   </a>
 </div>
 

--- a/FusionIIIT/templates/ais/ais.html
+++ b/FusionIIIT/templates/ais/ais.html
@@ -60,7 +60,7 @@ Academic Information System
                 <i class="right floated chevron right icon"></i>
             </a>
             <a class=" item" data-tab="proced_verify">
-                Verify Registered Courses
+                Verify Registered Students
                 <i class="right floated chevron right icon"></i>
             </a>
             <a class=" item" data-tab="proced_results">


### PR DESCRIPTION
Acadadmin dashboard has option to verify a student's registered courses, it is currently named as "verify registered course" which makes it unclear, this is replaced by "verify registered students"