### PR TITLE
Fixed Student Records Button Access

### DIFF
--- a/FusionIIIT/applications/placement_cell/views.py
+++ b/FusionIIIT/applications/placement_cell/views.py
@@ -209,6 +209,7 @@ def placement(request):
 
 
     form5 = AddSchedule(initial={})
+    current3 = HoldsDesignation.objects.filter(Q(working=user, designation__name="acadadmin"))
     current1 = HoldsDesignation.objects.filter(Q(working=user, designation__name="placement chairman"))
     current2 = HoldsDesignation.objects.filter(Q(working=user, designation__name="placement officer"))
     current = HoldsDesignation.objects.filter(Q(working=user, designation__name="student"))
@@ -473,6 +474,7 @@ def placement(request):
         'current': current,
         'current1': current1,
         'current2': current2,
+        'current3' : current3,
         'schedule_tab': schedule_tab,
         'schedules': schedules,
         'placementstatus': placementstatus,
@@ -932,6 +934,8 @@ def student_records(request):
     form9 = ManagePbiRecord(initial={})
     form11 = ManagePlacementRecord(initial={})
     form13 = SendInvite(initial={})
+    current = HoldsDesignation.objects.filter(Q(working=user, designation__name="acadadmin"))
+    current3 = HoldsDesignation.objects.filter(Q(working=user, designation__name="student"))
     current1 = HoldsDesignation.objects.filter(Q(working=user, designation__name="placement chairman"))
     current2 = HoldsDesignation.objects.filter(Q(working=user, designation__name="placement officer"))
 
@@ -1213,8 +1217,10 @@ def student_records(request):
         'form9': form9,
         'form11': form11,
         'form13': form13,
+        'current' : current,
         'current1': current1,
         'current2': current2,
+        'current3' : current3,
         'mnplacement_tab': mnplacement_tab,
         'strecord_tab': strecord_tab,
         'students': students,
@@ -1880,6 +1886,7 @@ def placement_statistics(request):
     form2 = SearchPlacementRecord(initial={})
     form3 = SearchPbiRecord(initial={})
     form4 = SearchHigherRecord(initial={})
+    current3 = HoldsDesignation.objects.filter(Q(working=user, designation__name="acadadmin"))
     current1 = HoldsDesignation.objects.filter(Q(working=user, designation__name="placement chairman"))
     current2 = HoldsDesignation.objects.filter(Q(working=user, designation__name="placement officer"))
     current = HoldsDesignation.objects.filter(Q(working=user, designation__name="student"))
@@ -2411,6 +2418,7 @@ def placement_statistics(request):
         'current'           :          current,
         'current1'          :         current1,
         'current2'          :         current2,
+        'current3'          :         current3,
         'statistics_tab'    :   statistics_tab,
         'pbirecord'         :        pbirecord,
         'placementrecord'   :  placementrecord,

--- a/FusionIIIT/templates/placementModule/placement.html
+++ b/FusionIIIT/templates/placementModule/placement.html
@@ -111,6 +111,13 @@
                     <i class="right floated chevron right icon"></i>
                 </a>
 
+                {% if current1 or current2 or current3 %}
+                <a class="{% if strecord_tab %}active item{% else %}item{% endif %}" href="{% url 'placement:student_records' %}">
+                  Student Records
+                  <i class="right floated chevron right icon"></i>
+                </a>
+                {% endif %}
+
             </div>
             {% comment %}The Tab-Menu ends here!{% endcomment %}
 

--- a/FusionIIIT/templates/placementModule/placementstatistics.html
+++ b/FusionIIIT/templates/placementModule/placementstatistics.html
@@ -111,6 +111,13 @@
                     <i class="right floated chevron right icon"></i>
                 </a>
 
+                {% if current1 or current2 or current3 %}
+                <a class="{% if strecord_tab %}active item{% else %}item{% endif %}" href="{% url 'placement:student_records' %}">
+                  Student Records
+                  <i class="right floated chevron right icon"></i>
+                </a>
+                {% endif %}
+
             </div>
             {% comment %}The Tab-Menu ends here!{% endcomment %}
 

--- a/FusionIIIT/templates/placementModule/studentrecords.html
+++ b/FusionIIIT/templates/placementModule/studentrecords.html
@@ -111,6 +111,13 @@
                     <i class="right floated chevron right icon"></i>
                 </a>
 
+                {% if current1 or current2 or current3 %} 
+                <a class="{% if strecord_tab %}active item{% else %}item{% endif %}" href="{% url 'placement:student_records' %}">
+                  Student Records
+                  <i class="right floated chevron right icon"></i>
+                </a>
+                {% endif %}
+
             </div>
             {% comment %}The Tab-Menu ends here!{% endcomment %}
 


### PR DESCRIPTION
Fixed the issue #785 where the students are also able to access the student records page through Student Records button while according to SRS, only Placement Officer and Chairman have the access to the page.

Now, Student records button is only visible to Acadadmin, placement officer and placement chairman and not to the Students.

![Screenshot (73)](https://user-images.githubusercontent.com/50803485/159205973-7a49bdb7-2827-4f8a-b45a-fdf207db459c.png)

