### PR TITLE
Fixed the issue #835 where student could not read notification

### DIFF
--- a/FusionIIIT/notification/views.py
+++ b/FusionIIIT/notification/views.py
@@ -36,7 +36,7 @@ def leave_module_notif(sender, recipient, type, date=None):
     notify.send(sender=sender, recipient=recipient, url=url, module=module, verb=verb)
 
 def placement_cell_notif(sender, recipient, type):
-    url = ''
+    url = 'placement:placement'
     module = 'Placement Cell'
     sender = sender
     recipient = recipient


### PR DESCRIPTION
Fixed issue #835. Now students can read the notification since the notification url is fixed.
Placement Officer can send a new invitation where students can get the notification for the new company.
The student can mark the notification as read.