### PR TITLE
Correction of rating precision

### DIFF
--- a/FusionIIIT/applications/globals/views.py
+++ b/FusionIIIT/applications/globals/views.py
@@ -1008,7 +1008,7 @@ def feedback(request):
         for feed in Feedback.objects.all():
             rating = rating + feed.rating
         if Feedback.objects.all().count() > 0:
-            rating = rating/Feedback.objects.all().count()
+            rating = round(rating/Feedback.objects.all().count(),1)
         context = {
             'form': form,
             "feedback": feedback,
@@ -1022,7 +1022,7 @@ def feedback(request):
     for feed in Feedback.objects.all():
         rating = rating + feed.rating
     if Feedback.objects.all().count() > 0:
-        rating = rating/Feedback.objects.all().count()
+        rating = round(rating/Feedback.objects.all().count(),1)
     try:
         feedback = Feedback.objects.select_related('user').get(user=request.user)
         form = WebFeedbackForm(instance=feedback)

--- a/FusionIIIT/templates/globals/feedback.html
+++ b/FusionIIIT/templates/globals/feedback.html
@@ -127,7 +127,7 @@ Fusion - Feedback
             	<center>
             		<i class="massive star icon yellow"></i>
             		<div class="ui massive header" style="font-size: 3em;">
-            			{{ rating }}
+            			{{ rating }} / 5.0
             		</div>
             	</center>
             	<div class="ui divider"></div>


### PR DESCRIPTION
## Issue that this pull request solves
I corrected the precision of the rating of Fusion on the feedback page.

## Proposed changes
In this, I had applied changes to
-> FusionIIIT/templates/globals/feedback.html 
-> FusionIIIT/applications/globals/views.py

### Brief description of what is fixed or changed
In FusionIIIT/applications/globals/views.py, I applied a round function to round off the calculated overall average rating.
In FusionIIIT/templates/globals/feedback.html , I had placed '/ 5.0' after variable {{rating}}.
## Types of changes

_Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply_

-   [ ] My code follows the [style guidelines of this project](https://docs.google.com/document/d/1GI2Hile8UbGZ82gFe1y4wAVPcNPXip1cmXTzog1S41U/edit)
-   [x] I have performed a self-review of my own code
-   [x] I have created a new branch for this pull request
-   [ ] I have commented on my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] My changes do not break the current system and it passes all the current test cases.

## Screenshots

Previously : 

<img width="1280" alt="Screenshot 2022-05-18 at 11 53 41 PM" src="https://user-images.githubusercontent.com/94986792/170011595-70eaf31e-5b17-4f0b-be8f-ff445fc546e6.png">

After applying changes: 

<img width="1280" alt="Screenshot 2022-05-18 at 11 54 49 PM" src="https://user-images.githubusercontent.com/94986792/170011677-7d985a9d-c3f5-4811-8101-7bb70e1df291.png">

