### PR TITLE
changed the input of roll from only integers to integers+alphabet

### DIFF
--- a/FusionIIIT/applications/placement_cell/forms.py
+++ b/FusionIIIT/applications/placement_cell/forms.py
@@ -376,7 +376,7 @@ class SearchStudentRecord(forms.Form):
     """
     name = forms.CharField(widget=forms.TextInput(attrs={'max_length': 100, 'class': 'field'}),
                            label="name", required=False)
-    rollno = forms.IntegerField(label="rollno", widget=forms.NumberInput(attrs={'min': 0}), required=False)
+    rollno = forms.CharField(label="rollno", widget=forms.TextInput(attrs={'min': 0}), required=False)
     programme = forms.ChoiceField(choices = Con.PROGRAMME, required=False,
                                   label="programme", widget=forms.Select(attrs={'style': "height:45px",
                                                                                 'onchange': "changeDeptForSearch()",
@@ -410,7 +410,7 @@ class SendInvite(forms.Form):
             company - name of company
     """
     company = forms.ModelChoiceField(required=True, queryset=NotifyStudent.objects.all(), label="company")
-    rollno = forms.IntegerField(label="rollno", widget=forms.NumberInput(attrs={'min': 0}), required=False)
+    rollno = forms.CharField(label="rollno", widget=forms.TextInput(attrs={'min': 0}), required=False)
     programme = forms.ChoiceField(choices = Con.PROGRAMME, required=False,
                                   label="programme", widget=forms.Select(attrs={'style': "height:45px",
                                                                                 'onchange': "changeDeptForSend()",
@@ -507,7 +507,7 @@ class SearchPlacementRecord(forms.Form):
                               label="stuname", required=False)
     year = forms.TypedChoiceField(coerce=int, choices=year_choices, initial=current_year, label="year", required=False, widget=forms.NumberInput(attrs={'id': 'add_placement_year'}))
     ctc = forms.CharField(label="ctc", required=False, widget=forms.NumberInput(attrs={ 'min':0, 'id': 'add_placement_ctc', 'step': 0.25}))
-    roll = forms.IntegerField(widget=forms.NumberInput(attrs={ 'min':0,
+    roll = forms.CharField(widget=forms.TextInput(attrs={ 'min':0,
                                                             'max_length': 10,
                                                             'class': 'form-control',
                                                             'id': 'add_placement_roll'}),
@@ -534,7 +534,7 @@ class SearchPbiRecord(forms.Form):
                               label="stuname", required=False)
     year = forms.TypedChoiceField(coerce=int, choices=year_choices, initial=current_year, label="year", required=False, widget=forms.NumberInput(attrs={'id': 'add_pbi_year'}))
     ctc = forms.DecimalField(label="ctc", required=False, widget=forms.NumberInput(attrs={ 'min':0, 'id': 'add_pbi_ctc', 'step': 0.25}))
-    roll = forms.IntegerField(widget=forms.NumberInput(attrs={ 'min':0,
+    roll = forms.CharField(widget=forms.TextInput(attrs={ 'min':0,
                                                             'max_length': 10,
                                                             'class': 'form-control',
                                                             'id': 'add_pbi_roll'}),
@@ -556,7 +556,7 @@ class SearchHigherRecord(forms.Form):
             year -year of clearing the test
             uname - name of the university
     """
-    roll = forms.IntegerField(widget=forms.NumberInput(attrs={ 'min':0, 'max_length': 10,
+    roll = forms.CharField(widget=forms.TextInput(attrs={ 'min':0, 'max_length': 10,
                                                           'class': 'form-control',
                                                           'id': 'add_higher_roll'}),
                            label="roll", required=False)
@@ -589,7 +589,7 @@ class ManagePlacementRecord(forms.Form):
     stuname = forms.CharField(widget=forms.TextInput(attrs={'max_length': 100,
                                                               'class': 'field'}),
                               label="stuname", required=False)
-    roll = forms.IntegerField(widget=forms.NumberInput(attrs={ 'min':0,
+    roll = forms.CharField(widget=forms.TextInput(attrs={ 'min':0,
                                                             'max_length': 10,
                                                             'class': 'form-control'}),
                             label="roll", required=False)
@@ -611,7 +611,7 @@ class ManagePbiRecord(forms.Form):
     stuname = forms.CharField(widget=forms.TextInput(attrs={'max_length': 100,
                                                               'class': 'field'}),
                                 label="stuname", required=False)
-    roll = forms.IntegerField(widget=forms.NumberInput(attrs={ 'min':0,
+    roll = forms.CharField(widget=forms.TextInput(attrs={ 'min':0,
                                                             'max_length': 10,
                                                             'class': 'form-control'}),
                             label="roll", required=False)
@@ -634,7 +634,7 @@ class ManageHigherRecord(forms.Form):
     stuname = forms.CharField(widget=forms.TextInput(attrs={'max_length': 100,
                                                               'class': 'field'}),
                                 label="stuname", required=False)
-    roll = forms.IntegerField(widget=forms.NumberInput(attrs={ 'min':0,
+    roll = forms.CharField(widget=forms.TextInput(attrs={ 'min':0,
                                                     'max_length': 10,
                                                     'class': 'form-control'}),
                             label="roll", required=False)


### PR DESCRIPTION
The roll no in forms of invitation and invitation status is taking only integers but after 2019 the roll no contain alphabets also

Closes: # (962)
changed the integer field input to char field input.

changed the all roll no input type under placement module from only integers to integers +alphabet.

## Types of changes

_Put an `x` in the boxes that apply_

-   [ x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply_

-   [ x] My code follows the [style guidelines of this project](https://docs.google.com/document/d/1GI2Hile8UbGZ82gFe1y4wAVPcNPXip1cmXTzog1S41U/edit)
-   [x ] I have performed a self-review of my own code
-   [ x] I have created new branch for this pull request
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x ] My changes generate no new warnings
-   [ x] My changes does not break the current system and it passes all the current test cases.

## Screenshots

Please attach the screenshots of the changes made in case of change in user interface
![image](https://user-images.githubusercontent.com/98115978/175664140-5603b8c6-2946-4f18-b0ff-f1300fdaac73.png)
![image](https://user-images.githubusercontent.com/98115978/175664209-09489d49-6dc9-4a6e-9d6b-5f0aa845a2bb.png)


## Other information

Any other information that is important to this pull request
