### PR TITLE
Add "File Complaint" feature to caretakers

### DIFF
--- a/FusionIIIT/templates/complaintModule/complaint_caretaker.html
+++ b/FusionIIIT/templates/complaintModule/complaint_caretaker.html
@@ -80,6 +80,11 @@
                     <i class="right floated chevron right icon"></i>
                 </a>
 
+                <a class="item"  href = "/complaint/user/"> {% comment %}Added function to add complaint as user{% endcomment %}
+                    File Complaint
+                    <i class="right floated chevron right icon"></i>
+                </a>
+
             </div>
             {% comment %}The Tab-Menu ends here!{% endcomment %}
 


### PR DESCRIPTION
## Add "File Complaint" feature to caretakers

Closes: #960 

## Added the option for the caretaker to file a complaint.

### We had added this feature below the same sidebar of the caretaker so that UI UX will not get affected. This is basically a simple <a> tag with a 'href' attribute directing it to user/complaint. We have tested it, it works just fantastic. The complaint appears with the name of the complaining caretaker.


## Types of changes

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Other (please describe):

## Checklist

-   [x] My code follows the [style guidelines of this project](https://docs.google.com/document/d/1GI2Hile8UbGZ82gFe1y4wAVPcNPXip1cmXTzog1S41U/edit)
-   [x] I have performed a self-review of my own code
-   [x] I have created new branch for this pull request
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots

<img width="1280" alt="Screenshot 2022-06-21 at 11 27 52 AM" src="https://user-images.githubusercontent.com/94986792/175767755-a9d5f110-014f-4fc4-adde-dc68ebf7ac4a.png">

