### PR TITLE
Add "File Complaint" feature to supervisor

### DIFF
--- a/FusionIIIT/templates/complaintModule/complaint_caretaker.html
+++ b/FusionIIIT/templates/complaintModule/complaint_caretaker.html
@@ -80,6 +80,11 @@
                     <i class="right floated chevron right icon"></i>
                 </a>
 
+                <a class="item"  href = "/complaint/user/"> {% comment %}Added function to add complaint as user{% endcomment %}
+                    File Complaint
+                    <i class="right floated chevron right icon"></i>
+                </a>
+
             </div>
             {% comment %}The Tab-Menu ends here!{% endcomment %}
 

--- a/FusionIIIT/templates/complaintModule/complaint_caretaker.html
+++ b/FusionIIIT/templates/complaintModule/complaint_caretaker.html
@@ -80,11 +80,6 @@
                     <i class="right floated chevron right icon"></i>
                 </a>
 
-                <a class="item"  href = "/complaint/user/"> {% comment %}Added function to add complaint as user{% endcomment %}
-                    File Complaint
-                    <i class="right floated chevron right icon"></i>
-                </a>
-
             </div>
             {% comment %}The Tab-Menu ends here!{% endcomment %}
 

--- a/FusionIIIT/templates/complaintModule/supervisor1.html
+++ b/FusionIIIT/templates/complaintModule/supervisor1.html
@@ -50,12 +50,11 @@
                 <a class="item" data-tab="fourth">
                     Overdue Complaints
                     <i class="right floated chevron right icon"></i>
+                </a>               
+                <a class="item"  href = "/complaint/user/"> {% comment %}Added function to add complaint as user{% endcomment %}
+                    File Complaint
+                    <i class="right floated chevron right icon"></i>
                 </a>
-
-               
-
-             
-
 
             </div>
             {% comment %}The Tab-Menu ends here!{% endcomment %}


### PR DESCRIPTION
## Add "File Complaint" feature to supervisor

Closes: #961 

## Created an option for the supervisor to file a complaint.

### We had added this feature below the same sidebar of the supervisor so that UI UX will not get affected. This is basically a simple tag with a 'href' attribute directing it to '/complaint/user/'. We have tested it, it works just fantastic. The complaint appears with the name of the complaining supervisor.

## Types of changes

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Other (please describe):

## Checklist

-   [x] My code follows the [style guidelines of this project](https://docs.google.com/document/d/1GI2Hile8UbGZ82gFe1y4wAVPcNPXip1cmXTzog1S41U/edit)
-   [x] I have performed a self-review of my own code
-   [x] I have created new branch for this pull request
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots

The feature is added below the sidebar:

<img width="1280" alt="Screenshot 2022-06-25 at 3 40 57 PM" src="https://user-images.githubusercontent.com/94986792/175769159-928934c6-5fd2-4768-895a-90b7f84cf0d7.png">


When we click on it, we get redirects to:

<img width="1280" alt="Screenshot 2022-06-25 at 3 41 07 PM" src="https://user-images.githubusercontent.com/94986792/175769151-1f6163cd-ad79-44d0-85f5-2e26f3866eac.png">

