### PR TITLE
feat: added user_sem and year constraints to pre registration eligibility check

### DIFF
--- a/FusionIIIT/applications/academic_procedures/views.py
+++ b/FusionIIIT/applications/academic_procedures/views.py
@@ -313,7 +313,6 @@ def academic_procedures_student(request):
             branchchange_flag=True
 
         pre_registration_date_flag = get_pre_registration_eligibility(current_date, user_sem, year)
-        # print("PRD: ", pre_registration_date_flag)
         final_registration_date_flag = get_final_registration_eligibility(current_date)
         add_or_drop_course_date_flag = get_add_or_drop_course_date_eligibility(current_date)
         pre_registration_flag = False
@@ -329,8 +328,6 @@ def academic_procedures_student(request):
         # print(">>>>>>>>>>>>>>>>>>>>>>",student_registration_check_pre.pre_registration_flag)
         
         acad_year = get_acad_year(user_sem, year)
-        # print("acad_year: ", year)
-        # print("user_sem: ", user_sem)
         currently_registered_courses = get_currently_registered_courses(user_details.id, user_sem)
 
         next_sem_branch_course = get_sem_courses(next_sem_id, batch)
@@ -1239,7 +1236,6 @@ def get_pre_registration_eligibility(current_date, user_sem, year):
         
     '''
     try:
-        # print(f"Pre Registration {user_sem} {year}")
         # pre_registration_date = Calendar.objects.all().filter(description="Pre Registration").first()
         pre_registration_date = Calendar.objects.all().filter(description=f"Pre Registration {user_sem} {year}").first()
         prd_start_date = pre_registration_date.from_date

--- a/FusionIIIT/applications/academic_procedures/views.py
+++ b/FusionIIIT/applications/academic_procedures/views.py
@@ -264,7 +264,7 @@ def academic_procedures_student(request):
         year = demo_date.year
         
         registers = get_student_register(user_details.id)
-        user_sem = get_user_semester(request.user, ug_flag, masters_flag, phd_flag)
+        # user_sem = get_user_semester(request.user, ug_flag, masters_flag, phd_flag)
         user_branch = get_user_branch(user_details)
 
         batch = obj.batch_id
@@ -297,8 +297,12 @@ def academic_procedures_student(request):
         curr_sem_id = Semester.objects.get(curriculum = curr_id, semester_no = obj.curr_semester_no)
 
         try:
+            semester_no = obj.curr_semester_no+1
             next_sem_id = Semester.objects.get(curriculum = curr_id, semester_no = obj.curr_semester_no+1)
+            user_sem = semester_no
+            
         except Exception as e:
+            user_sem = get_user_semester(request.user, ug_flag, masters_flag, phd_flag)
             next_sem_id = curr_sem_id
 
         student_registration_check_pre = get_student_registrtion_check(obj,next_sem_id)

--- a/FusionIIIT/applications/academic_procedures/views.py
+++ b/FusionIIIT/applications/academic_procedures/views.py
@@ -312,7 +312,8 @@ def academic_procedures_student(request):
         if user_sem==2 and des_flag==False and ug_flag==True:
             branchchange_flag=True
 
-        pre_registration_date_flag = get_pre_registration_eligibility(current_date)
+        pre_registration_date_flag = get_pre_registration_eligibility(current_date, user_sem, year)
+        # print("PRD: ", pre_registration_date_flag)
         final_registration_date_flag = get_final_registration_eligibility(current_date)
         add_or_drop_course_date_flag = get_add_or_drop_course_date_eligibility(current_date)
         pre_registration_flag = False
@@ -326,7 +327,10 @@ def academic_procedures_student(request):
             final_registration_flag = student_registration_check_final.final_registration_flag
 
         # print(">>>>>>>>>>>>>>>>>>>>>>",student_registration_check_pre.pre_registration_flag)
+        
         acad_year = get_acad_year(user_sem, year)
+        # print("acad_year: ", year)
+        # print("user_sem: ", user_sem)
         currently_registered_courses = get_currently_registered_courses(user_details.id, user_sem)
 
         next_sem_branch_course = get_sem_courses(next_sem_id, batch)
@@ -1214,9 +1218,30 @@ def phd_details(request):
 def get_student_register(id):
     return Register.objects.all().select_related('curr_id','student_id','curr_id__course_id','student_id__id','student_id__id__user','student_id__id__department').filter(student_id = id)
 
-def get_pre_registration_eligibility(current_date):
+def get_pre_registration_eligibility(current_date, user_sem, year):
+    '''
+        This function is used to extract the elgibility of pre-registration for a given semester
+        for a given year from the Calendar table.
+        
+        @param:
+                current_date - current date at the user end
+                user_sem - current semester of the user(integer)
+                year - current year at the user end
+
+        @variables:
+               pre_registration_date - stores the object returned from calendar table for a given description
+               prd_start_date - holds start date of the pre registeration
+               prd_end_date - holds end date of the pre registration
+               
+        #exception handling:
+        In case calendar table has no row for the  given description pre_registration_date will store None value,
+        Therefore from_date and to_date attributes cannot be accessed so the function will return False.
+        
+    '''
     try:
-        pre_registration_date = Calendar.objects.all().filter(description="Pre Registration").first()
+        # print(f"Pre Registration {user_sem} {year}")
+        # pre_registration_date = Calendar.objects.all().filter(description="Pre Registration").first()
+        pre_registration_date = Calendar.objects.all().filter(description=f"Pre Registration {user_sem} {year}").first()
         prd_start_date = pre_registration_date.from_date
         prd_end_date = pre_registration_date.to_date
         if current_date>=prd_start_date and current_date<=prd_end_date:

--- a/FusionIIIT/applications/academic_procedures/views.py
+++ b/FusionIIIT/applications/academic_procedures/views.py
@@ -298,7 +298,7 @@ def academic_procedures_student(request):
 
         try:
             semester_no = obj.curr_semester_no+1
-            next_sem_id = Semester.objects.get(curriculum = curr_id, semester_no = obj.curr_semester_no+1)
+            next_sem_id = Semester.objects.get(curriculum = curr_id, semester_no = semester_no)
             user_sem = semester_no
             
         except Exception as e:


### PR DESCRIPTION
## Issue that this pull request solves
Before if the pre registration date was set irrespective of the semester and year registration form was open to all. 

## Proposed changes:
Added user_sem and year constraints to check the eligibility for pre registration to increase security and reduce duplicity.

### Brief description of what is fixed or changed:
changed ```def get_pre_registration_eligibility(current_date):``` to ```def get_pre_registration_eligibility(current_date, user_sem, year):```

## Types of changes

_Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply_

-   [x] My code follows the [style guidelines of this project](https://docs.google.com/document/d/1GI2Hile8UbGZ82gFe1y4wAVPcNPXip1cmXTzog1S41U/edit)
-   [x] I have performed a self-review of my own code
-   [ ] I have created new branch for this pull request
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] My changes does not break the current system and it passes all the current test cases.
