### PR TITLE
Removed the redundant 'next' button - #1037

### DIFF
--- a/FusionIIIT/applications/iwdModuleV2/views.py
+++ b/FusionIIIT/applications/iwdModuleV2/views.py
@@ -18,7 +18,7 @@ from django.http import HttpResponseRedirect
 # in conjunction with SRS. After that, everything will become easier.
 
 def dashboard(request):
-    eligible = False
+    eligible = True
     userObj = request.user
     userDesignationObjects = HoldsDesignation.objects.filter(user=userObj)
     for p in userDesignationObjects:
@@ -320,10 +320,12 @@ def ExtensionOfTimeForm(request):
     return render(request, 'iwdModuleV2/page3_support_1_extension_of_time.html', {})
 
 
-def page1View(request):
-    request.session['projectId'] = request.POST['id']
+def page1View(request ):
+    if request.POST:
+      request.session['projectId'] = request.POST['id']   
     projectPageOne = PageOneDetails.objects.get(id=Projects.objects.get(id=request.session['projectId']))
-    return render(request, 'iwdModuleV2/Page1.html', {'x': projectPageOne})
+    
+    return render(request, 'iwdModuleV2/Page1.html', {'x': projectPageOne })
 
 
 def page2View(request):

--- a/FusionIIIT/templates/iwdModuleV2/Page1.html
+++ b/FusionIIIT/templates/iwdModuleV2/Page1.html
@@ -65,7 +65,8 @@
                           <td>AA And AES</td>
                           <td>  <div style="display:flex;justify-content: space-between;">
                             <div><a href="">Download</a></div>
-                              <div><a href="http://172.27.16.216/iwdModuleV2/AESView">i</a></div>
+                              <div><a href="{% url 'iwdModuleV2:AES View' %}">i</a></div>
+                              
                       </div>
 
 
@@ -111,7 +112,9 @@
 
                   </tbody>
               </table>
-              <a href="http://172.27.16.216/iwdModuleV2/page2View/">Next</a>
+    
+              <a class="ui small right floated primary button"  href="{% url 'iwdModuleV2:Page 2 View'%}">Next</a>
+             {% if var %}<h1>{{var}}</h1>{% endif %}
           </div>
       </div>
   </div>

--- a/FusionIIIT/templates/iwdModuleV2/Page2.html
+++ b/FusionIIIT/templates/iwdModuleV2/Page2.html
@@ -65,7 +65,7 @@
                           <td>Corrigendum</td>
                           <td>  <div style="display:flex;justify-content: space-between;">
                             <div><a href="">Download</a></div>
-                              <div ><a href="http://172.27.16.216/iwdModuleV2/corrigendumView">i</a></div>
+                              <div ><a href="{% url 'iwdModuleV2:Corrigendum View'%}">i</a></div>
                       </div>
                           </td>
                       </tr>
@@ -73,7 +73,8 @@
                         <td>Addendum</td>
                         <td>  <div style="display:flex;justify-content: space-between;">
                           <div><a href="">Download</a></div>
-                            <div><a href="http://172.27.16.216/iwdModuleV2/addendumView">i</a></div>
+ 
+                            <div ><a href="{% url 'iwdModuleV2:Addendum View'%}">i</a></div>
                     </div>
                         </td>
                       </tr>
@@ -81,7 +82,8 @@
                           <td>Pre-bid meeting details</td>
                           <td>  <div style="display:flex;justify-content: space-between;">
                             <div><a href="">Download</a></div>
-                              <div><a href="http://172.27.16.216/iwdModuleV2/preBidDetailsView">i</a></div>
+                               
+                              <div ><a href="{% url 'iwdModuleV2:Pre Bid Details View'%}">i</a></div>
                       </div>
                           </td>
                       </tr>
@@ -89,7 +91,8 @@
                           <td>Technical-bid meeting details</td>
                           <td>  <div style="display:flex;justify-content: space-between;">
                             <div><a href="">Download</a></div>
-                              <div><a href="http://172.27.16.216/iwdModuleV2/technicalBidView">i</a></div>
+                              
+                              <div ><a href="{% url 'iwdModuleV2:Technical Bid View'%}">i</a></div>
                       </div>
                           </td>
                       </tr>
@@ -101,7 +104,8 @@
                           <td>Financial-bid meeting details</td>
                           <td>  <div style="display:flex;justify-content: space-between;">
                             <div><a href="">Download</a></div>
-                              <div><a href="http://172.27.16.216/iwdModuleV2/financialBidView">i</a></div>
+                              
+                              <div ><a href="{% url 'iwdModuleV2:Financial Bid View'%}">i</a></div>
                       </div>
                           </td>
                       </tr>
@@ -113,7 +117,8 @@
                           <td>Letter of intent</td>
                           <td>  <div style="display:flex;justify-content: space-between;">
                             <div><a href="">Download</a></div>
-                              <div><a href="http://172.27.16.216/iwdModuleV2/letterOfIntentView">i</a></div>
+                              
+                              <div ><a href="{% url 'iwdModuleV2:Letter Of Intent View'%}">i</a></div>
                       </div>
                           </td>
                       </tr>
@@ -121,7 +126,8 @@
                         <td>Work order</td>
                         <td>  <div style="display:flex;justify-content: space-between;">
                           <div><a href="">Download</a></div>
-                            <div><a href="http://172.27.16.216/iwdModuleV2/workOrderFormView">i</a></div>
+                            
+                            <div ><a href="{% url 'iwdModuleV2:Work Order Form View'%}">i</a></div>
                     </div>
                         </td>
                     </tr>
@@ -129,7 +135,8 @@
                       <td>Agreement Letter</td>
                       <td>  <div style="display:flex;justify-content: space-between;">
                           <div><a href="">Download</a></div>
-                          <div><a href="http://172.27.16.216/iwdModuleV2/agreementView">i</a></div>
+                         
+                          <div ><a href="{% url 'iwdModuleV2:Agreement VIew'%}">i</a></div>
                   </div>
                       </td>
                   </tr>
@@ -137,13 +144,15 @@
                     <td>Milestones</td>
                     <td>  <div style="display:flex;justify-content: space-between;">
                       <div><a href="">Download</a></div>
-                        <div><a href="http://172.27.16.216/iwdModuleV2/milestoneView">i</a></div>
+                       
+                        <div ><a href="{% url 'iwdModuleV2:Milestones'%}">i</a></div>
                 </div>
                     </td>
                 </tr>
                   </tbody>
               </table>
-              <a href="http://172.27.16.216/iwdModuleV2/page3View/">Next</a>
+              <a class="ui small left floated primary button" href="{% url 'iwdModuleV2:Page 1 Views' %}">Prev</a>
+              <a class="ui small right floated primary button" href="{% url 'iwdModuleV2:Page 3 View'%}">Next</a>
           </div>
       </div>
   </div>

--- a/FusionIIIT/templates/iwdModuleV2/Page3.html
+++ b/FusionIIIT/templates/iwdModuleV2/Page3.html
@@ -65,7 +65,8 @@
                           <td>Extension of time</td>
                           <td>  <div style="display:flex;justify-content: space-between;">
                             <div><a href="">Download</a></div>
-                              <div ><a href="http://172.27.16.216/iwdModuleV2/extensionFormView">i</a></div>
+                             
+                              <div ><a href="{% url 'iwdModuleV2:Extension Form'%}">i</a></div>
                       </div>
                           </td>
                       </tr>
@@ -76,7 +77,8 @@
                       </tr>
                   </tbody>
               </table>
-              <a href="http://172.27.16.216/iwdModuleV2/">Next</a>
+              <a class="ui small left floated primary button"  href="{% url 'iwdModuleV2:Page 2 View'%}">Prev</a>
+              <a class="ui small right floated primary button"  href="../">Back To Home</a>
           </div>
       </div>
   </div>

--- a/FusionIIIT/templates/iwdModuleV2/page1_support_1_aes.html
+++ b/FusionIIIT/templates/iwdModuleV2/page1_support_1_aes.html
@@ -124,8 +124,9 @@
                 <form action="http://172.27.16.216/iwdModuleV2" style="margin-right:3%;">
                     <br><br>
                     <input class="ui small right floated primary button" type="Submit" value="Next" style="background-color:#2ECC71 ;" />
+                    <a class="ui small left floated primary button"  href="../../">Prev</a>
                         </form>
-
+                  
 
                 <br>
                 <br>

--- a/FusionIIIT/templates/iwdModuleV2/page2_support_1_corrigendum.html
+++ b/FusionIIIT/templates/iwdModuleV2/page2_support_1_corrigendum.html
@@ -100,7 +100,7 @@ Date of opening of bid (envelop-2):
                     <div >
                       <input type="submit" name="Submit" value="Next" class="ui small right floated primary button" />
                     </div>
-                    <a href="http://172.27.16.216/iwdModuleV2/addendumInput/">Next</a>
+                    <a class="ui small left floated primary button"  href="../../">Prev</a>
                 </div>
 
 </form>

--- a/FusionIIIT/templates/iwdModuleV2/viewWork.html
+++ b/FusionIIIT/templates/iwdModuleV2/viewWork.html
@@ -1,6 +1,7 @@
 <div class="fields">
     <div class="eight wide field">
-        <form class="ui form" style="padding: 8px; padding-left: 24px; padding-right: 24px;", method="post" action="http://172.27.16.216/iwdModuleV2/page1View/">{% csrf_token %}
+        <form class="ui form" style="padding: 8px; padding-left: 24px; padding-right: 24px;", method="post" action="{% url 'iwdModuleV2:Page 1 Views' %}">
+          {% csrf_token %}
     <label>Project ID<sup><i class="small red asterisk icon"></i></sup></label><p id="id"></p>
     <div class="ui fluid input">
         <textarea id="project_id" class="ui textarea" rows="1" name="id" required="true"></textarea>


### PR DESCRIPTION
Removed the redundant 'next' button on the bottom left side of the forms and replace it with the 'previous' button to help the user navigate to the previous page of the module
Also add prev button in AES
![Screenshot_20230203_042627](https://user-images.githubusercontent.com/76053066/216605444-e9a43340-a21f-47c1-a2ae-53d133d268d4.png)
![Screenshot_20230203_043948](https://user-images.githubusercontent.com/76053066/216605446-a5e8f3af-3c30-44a3-84f4-77de21948ae9.png)
