### PR TITLE
Fix #1041: OS-2 - Web - User Interface in History Section

### DIFF
--- a/FusionIIIT/templates/phcModule/history.html
+++ b/FusionIIIT/templates/phcModule/history.html
@@ -339,28 +339,27 @@
                                                           margin: auto;">
                 <thead>
                 <tr>
-
+                    <th>
+                        Date
+                    </th>
+                
                     <th class="three wide">
                         Doctor
                     </th>
 
                     <th>
                       Description
-                    </th>
-
-                    <th>
-                     Date
-                    </th>
-
-                  
-
-
+                    </th>               
                 </tr>
                 </thead>
 
                 <tbody>
                 {% for appointment in appointments %}
                 <tr>
+                    <td style="white-space:nowrap;">
+                        {{appointment.date}}
+                    </td>
+                    
                     <td>
                         {{appointment.doctor_id}}
                     </td>
@@ -368,16 +367,9 @@
                     <td>
                         {{appointment.description}}
                     </td>
-
-                    <td style="white-space:nowrap;">
-                        {{appointment.date}}
-                    </td>
-
                    
 					<td>
-
                         <input type="button" onclick="rm({{appointment.pk}})" id="{{appointment.pk}}" name="cancel" value="Cancel"class="ui red button" />
-
                     </td> 
                 </tr>
                 {% endfor %}
@@ -419,26 +411,28 @@
             <table class="ui very basic collapsing celled large fluid sortable table"
                    style="padding-left: 2.5%;padding-right: 2.5%;padding-top: 1%;padding-bottom: 1.5%;margin: auto;">
                 <thead>
-                <tr>
-                    <th class="four wide">
-                      Feedback
-                    </th >
+                    <tr>
+                        <th class="four wide">
+                            Date
+                        </th>
+                        
+                        <th class="four wide">
+                        Feedback
+                        </th >
 
-                    <th class="six wide">
-                      Response
-                    </th>
-
-                    <th class="four wide">
-                        Date
-                    </th>
-
-                </tr>
+                        <th class="six wide">
+                        Response
+                        </th>
+                    </tr>
                 </thead>
 
                 <tbody>
                   {% for complaint in complaints %}
                 <tr>
-
+                    <td>
+                        {{complaint.date}}
+                    </td>
+                    
                     <td>
                         {{complaint.complaint}}
                     </td>
@@ -450,11 +444,6 @@
                         {{complaint.feedback}}
                       {% endif %}
                     </td>
-
-                    <td>
-                        {{complaint.date}}
-                    </td>
-
                 </tr>
                 {% endfor %}
                 </tbody>


### PR DESCRIPTION
## Issue that this pull request solves

Closes: #1041 

## Proposed changes
- Reorder the date tab to the beginning of the interface.

### Brief description of what is fixed or changed
- The proposed changes have been applied.

## Types of changes
- Minor UI changes.

_Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply_

-   [x] My code follows the [style guidelines of this project](https://docs.google.com/document/d/1GI2Hile8UbGZ82gFe1y4wAVPcNPXip1cmXTzog1S41U/edit)
-   [x] I have performed a self-review of my own code
-   [x] I have created new branch for this pull request
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots
![image](https://user-images.githubusercontent.com/68158825/216610261-b441d135-d945-4564-abee-964a29fcee6e.png)
![image](https://user-images.githubusercontent.com/68158825/216610277-f765b8dc-6ae8-4611-8340-3d5b90db24d6.png)
