### PR TITLE
ac-5: Fix form render for students of 2020 batch and later

### DIFF
--- a/FusionIIIT/applications/scholarships/views.py
+++ b/FusionIIIT/applications/scholarships/views.py
@@ -99,13 +99,11 @@ def convener_view(request):
             )
             
             # It updates the student Notification table on the spacs head sending the mcm invitation
-            if batch == 'all':
+            if batch.lower() == 'all':
                 active_batches = range(datetime.datetime.now().year - 4 , datetime.datetime.now().year + 1)
-                query = reduce(or_, (Q(id__id__startswith=batch) for batch in active_batches))
-                recipient = Student.objects.filter(programme=programme).filter(query)
+                recipient = Student.objects.filter(programme=programme).filter(batch__in=active_batches)
             else:
-                recipient = Student.objects.filter(programme=programme, id__id__startswith=batch)
-            
+                recipient = Student.objects.filter(programme=programme, batch=batch)
             # Notification starts
             convenor = request.user
             for student in recipient:
@@ -1013,7 +1011,6 @@ def sendConvenerRenderRequest(request, additionalParams={}):
     source = Constants.FATHER_OCC_CHOICE
     time = Constants.TIME
     release = Release.objects.all()
-    notification = Notification.objects.select_related('student_id','release_id').all()
     spi = Spi.objects.all()
     context.update({ 'source': source, 'time': time, 'ch': ch, 'spi': spi, 'release': release})
     context.update(additionalParams)

--- a/FusionIIIT/templates/dashboard/modules.html
+++ b/FusionIIIT/templates/dashboard/modules.html
@@ -116,7 +116,7 @@
                     {% comment %}A single modules row starts here!{% endcomment %}
                     <div class="row">
                         <div class="column">
-                            <a class="ui large label disabled" href="/spacs">
+                            <a class="ui large label" href="/spacs">
                                 <div class="ui centered grid">
                                     <div class="row">
                                         <i class="ui student icon big"></i>


### PR DESCRIPTION
## Issue that this pull request solves

Closes: #1102 

## Proposed changes
In code where the notification to the respective students is being sent, we need to change the query to fetch students by batch field instead of id field as that is more concrete and stable for any upcoming batches even if roll number format changes again.

### Brief description of what is fixed or changed
The query for fetching students to whom the notifications need to sent is updated to use matching based on batch field instead of id field

## Types of changes

_Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply_

-   [x] My code follows the [style guidelines of this project](https://docs.google.com/document/d/1GI2Hile8UbGZ82gFe1y4wAVPcNPXip1cmXTzog1S41U/edit)
-   [x] I have performed a self-review of my own code
-   [x] I have created new branch for this pull request
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots



## Other information


