### PR TITLE
fix(AC2): Fixed message shown after pre registration window closes.

### DIFF
--- a/FusionIIIT/templates/academic_procedures/auto_pre_registration.html
+++ b/FusionIIIT/templates/academic_procedures/auto_pre_registration.html
@@ -69,7 +69,6 @@
 <center><b>Pre-Registration for Next Semester Courses</b></center>
 <div class="ui vertical segment">
     {% if curr_sem.semester_no != 8 %}
-    {% if prd %}
     {% if pre_registration_flag %}
     <B style="color:red">
         <CENTER> You have already registered at
@@ -137,6 +136,7 @@
         </center>
     </CENTER>
     {% else %}
+    {% if prd %}
     <form id='student_register' action='/academic-procedures/auto_pre_registration/'>
         {% csrf_token %}
         <table id="registration_courses_table" class="ui very basic collapsing celled sortable table" style="padding-left: 2.5%;
@@ -254,8 +254,6 @@
 
     <br>
     <br>
-
-    {% endif %}
     {% else %}
     {% if prd_start_date%}
     <B>
@@ -265,6 +263,8 @@
     <B>
         <CENTER> Pre Registration date hasn't come yet
     </B></CENTER>
+    {% endif %}
+
     {% endif %}
     {% endif %}
     {% else %}


### PR DESCRIPTION
## Issue that this pull request solves

Closes: # (issue number)

## Proposed changes
- Once the pre registration window closes and student has completed his pre registration he is shown message: "You have already registered at `timestamp` !!!"


### Brief description of what is fixed or changed

## Types of changes

_Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply_

-   [x] My code follows the [style guidelines of this project](https://docs.google.com/document/d/1GI2Hile8UbGZ82gFe1y4wAVPcNPXip1cmXTzog1S41U/edit)
-   [x] I have performed a self-review of my own code
-   [ ] I have created new branch for this pull request
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] My changes does not break the current system and it passes all the current test cases.

## Screenshots

Please attach the screenshots of the changes made in case of change in user interface

## Other information

Any other information that is important to this pull request
