### PR TITLE
fix(add_course): Show only relevant semesters in the add course form

### DIFF
--- a/FusionIIIT/applications/academic_procedures/views.py
+++ b/FusionIIIT/applications/academic_procedures/views.py
@@ -1087,7 +1087,7 @@ def verify_course(request):
         # TO DO Bdes
         date = {'year': yearr, 'semflag': semflag}
         course_list = Courses.objects.all()
-        semester_list = Semester.objects.all()
+        semester_list = Semester.objects.filter(curriculum=curr_id)
         semester_no_list=[]
         for i in semester_list:
             semester_no_list.append(int(i.semester_no))

--- a/FusionIIIT/templates/academic_procedures/studentCourses.html
+++ b/FusionIIIT/templates/academic_procedures/studentCourses.html
@@ -1,6 +1,9 @@
 {% load static %}
 
 <script>
+    $(document).ready(function() {
+        $('.ui.dropdown').dropdown();
+    });
     let addCourseButton = document.querySelector(".addCourseButton");
     addCourseButton.addEventListener("click",()=>
         { 
@@ -137,12 +140,16 @@
                 {% csrf_token %}
                 <div class="field">
                     <label>Course </label>
-                    <select class="ui fluid dropdown" name = "course_id">
-                        <option value="">Select</option>
-                        {% for course in course_list %}
-                            <option value="{{course.id}}">{{course.code}} - {{course.name}}</option>
-                        {% endfor%}
-                    </select>
+                    <div class="ui fluid search selection dropdown">
+                        <input type="hidden" name="course_id">
+                        <i class="dropdown icon"></i>
+                        <div class="default text">Select</div>
+                        <div class="menu">
+                            {% for course in course_list %}
+                            <div class="item" data-value="{{ course.id }}">{{ course.code }} - {{ course.name }}</div>
+                            {% endfor %}
+                        </div>
+                    </div>
                 </div>
                 <div class="field">
                     <label>Semester Id</label>


### PR DESCRIPTION
## Issue that this pull request solves

Closes: # (issue number)

## Proposed changes
- Show only relevant semesters in the add course form

### Brief description of what is fixed or changed

## Types of changes

_Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply_

-   [ ] My code follows the [style guidelines of this project](https://docs.google.com/document/d/1GI2Hile8UbGZ82gFe1y4wAVPcNPXip1cmXTzog1S41U/edit)
-   [x] I have performed a self-review of my own code
-   [ ] I have created new branch for this pull request
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] My changes does not break the current system and it passes all the current test cases.

## Screenshots

Please attach the screenshots of the changes made in case of change in user interface

## Other information

Any other information that is important to this pull request
