### PR TITLE
fix(registration): Fixed bug in final registration and allot courses for acad admin

### DIFF
--- a/FusionIIIT/applications/academic_procedures/views.py
+++ b/FusionIIIT/applications/academic_procedures/views.py
@@ -1655,7 +1655,7 @@ def allot_courses(request):
                     print(course_code.strip() , course_name.strip())
                     course = Courses.objects.get(code=course_code.strip(),name=course_name.strip())
                     if(roll_no not in currroll):
-                        student_check=StudentRegistrationChecks(student_id = student, semester_id = sem_id, pre_registration_flag = True,final_registration_flag = False)
+                        student_check=StudentRegistrationChecks(student_id = student, semester_id = sem_id, pre_registration_flag = True,final_registration_flag = True)
                         student_checks.append(student_check)
                         currroll.add(roll_no)
                     # print(">>>>>",roll_no,course_slot_name,course_code,course_name)
@@ -1665,7 +1665,7 @@ def allot_courses(request):
                                                     course_id=course,semester_id=sem_id,priority=1)
                 pre_registrations.append(pre_registration)
                 final_registration=FinalRegistration(student_id=student,course_slot_id=course_slot,
-                                                    course_id=course,semester_id=sem_id)
+                                                    course_id=course,semester_id=sem_id, verified=True )
                 final_registrations.append(final_registration)
     
                 courseregistration=course_registration(working_year=datetime.datetime.now().year,course_id=course,semester_id=sem_id,student_id=student,course_slot_id=course_slot)
@@ -2619,8 +2619,9 @@ def course_list(request):
         student_id = request_body['student_id']
         semester_id = request_body['semester_id']
  
-        final_registration_table = FinalRegistration.objects.all().filter(semester_id = semester_id, verified = False)
-        final = final_registration_table.filter(student_id = student_id, semester_id = semester_id)
+        # final_registration_table = FinalRegistration.objects.all().filter(semester_id = semester_id, verified = False)
+        # final = final_registration_table.filter(student_id = student_id, semester_id = semester_id)
+        final = FinalRegistration.objects.all().filter(semester_id__semester_no = semester_id, student_id__id=student_id, verified = False)
         html = render_to_string('academic_procedures/student_course_list.html',{"course_list":final}, request)
  
         return HttpResponse(json.dumps({'html': html}),content_type="application/json")
@@ -2717,6 +2718,14 @@ def auto_verify_registration(request):
         with transaction.atomic():
             for obj in final_register_list:
                 o = FinalRegistration.objects.filter(id= obj.id).update(verified = True)
+                course_registration.objects.create(
+                    student_id=obj.student_id,
+                    course_id=obj.course_id,
+                    semester_id=obj.semester_id,
+                    course_slot_id=obj.course_slot_id,
+                    registration_type=obj.registration_type,
+                    working_year=demo_date.year  # Set the current year
+                )
             academics_module_notif(request.user, student.id.user, 'registration_approved')
             
             Student.objects.filter(id = student_id).update(curr_semester_no = sem_no)


### PR DESCRIPTION
## Issue that this pull request solves
- When acad admin verifies registered students the courses that the student has registered for should be visible and after approval final registration data should be sent to course_registration table.
- When acad admin allot courses using excel `final_registration_flag` should be true in `StudentRegistrationChecks` table and `verified` should be true in `FinalRegistration` table.

Closes: # (issue number)

## Proposed changes

### Brief description of what is fixed or changed
- Made appropriate changes to solve the issues mentioned above.

## Types of changes

_Put an `x` in the boxes that apply_

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply_

-   [x] My code follows the [style guidelines of this project](https://docs.google.com/document/d/1GI2Hile8UbGZ82gFe1y4wAVPcNPXip1cmXTzog1S41U/edit)
-   [x] I have performed a self-review of my own code
-   [ ] I have created new branch for this pull request
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] My changes does not break the current system and it passes all the current test cases.

## Screenshots

Please attach the screenshots of the changes made in case of change in user interface

## Other information

Any other information that is important to this pull request
