### PR TITLE
(academics):restricted the page reload for acad admin drop courses fe…

### DIFF
--- a/FusionIIIT/applications/academic_procedures/views.py
+++ b/FusionIIIT/applications/academic_procedures/views.py
@@ -2168,7 +2168,7 @@ def get_currently_registered_course(id, sem_id, courseregobj=False):
     if (type(sem_id) == int):
         obj = course_registration.objects.all().filter(student_id = id, semester_id__semester_no=sem_id)
     else:
-        obj = course_registration.objects.all().filter(student_id = id)
+        obj = course_registration.objects.all().filter(student_id = id).order_by('-semester_id_id')
     courses = []
     for i in obj:
         if (courseregobj):

--- a/FusionIIIT/templates/academic_procedures/studentCourses.html
+++ b/FusionIIIT/templates/academic_procedures/studentCourses.html
@@ -10,28 +10,42 @@
                 .modal('show')
                 ;
             });  
-    });
-        function courseDropCalled(event) {
-        // Prevent the default action of the link
-        event.preventDefault();
-        
-        // Get the URL from the link's href attribute
-        let url = event.target.href;
-
-        // Perform AJAX request
-        $.ajax({
-            url: url,
-            type: 'GET',
-            success: function(data) {
-                // Reload the page after successful deletion
-                location.reload();
-            },
-            error: function(xhr, status, error) {
-                // Handle errors if needed
-                console.error(error);
-            }
+        let url = "";
+        let rowToDelete;
+        $('.trigger-link-acad').on('click', function (event) {
+            event.preventDefault(); // Prevent the default behavior of the link
+            url = event.target.href
+            rowToDelete = $(this).closest('tr');
+            course_name = $(this).attr('course_name_stu')
+            course_code = $(this).attr('course_code_stu')
+            $('.course_details_stu').html('Are you sure you want to drop '+course_code+'-'+course_name +'?');
+            $('#confirmation-modal-acad').modal('show'); // Show the modal
         });
-    }
+
+        // Handle Cancel button
+        $('#cancel-button-acad-course').on('click', function () {
+            $('#confirmation-modal-acad').modal('hide'); // Hide the modal
+        });
+
+        // Handle OK button
+        $('#confirm-button-acad').on('click', function () {
+            $('#confirmation-modal-acad').modal('hide'); // Hide the modal
+            
+            // Perform AJAX API call
+            $.ajax({
+                url: url,
+                type: 'GET',
+                success: function(data) {
+                    rowToDelete.remove();
+                    alert('course dropped successfully')
+                },
+                error: function(xhr, status, error) {
+                    // Handle errors if needed
+                    console.error(error);
+                }
+            });
+        });
+    });
 </script>
 
 
@@ -110,8 +124,8 @@
                         {{ items.registration_type }}
                     </td>
                     <td>
-                        <A class="ui blue label"
-                            href="/academic-procedures/acad_person/verifyCourse/drop/?id={{ items.reg_id|urlencode }}" onclick="courseDropCalled(event)" >
+                        <A class="trigger-link-acad ui blue label"
+                            href="/academic-procedures/acad_person/verifyCourse/drop/?id={{ items.reg_id|urlencode }}" course_code_stu="{{items.course_id}}" course_name_stu = "{{items.course_name}}" >
                             DROP </A>
                     </td>
 
@@ -190,5 +204,18 @@
           </div>
 
         
+    </div>
+</div>
+
+<div class="ui warning modal" id="confirmation-modal-acad">
+    <div class="header">Confirmation Required</div>
+    <div class="ui warning content">
+        <ul>
+            <li class="course_details_stu"></li>
+        </ul>
+    </div>
+    <div class="actions">
+        <button class="ui red button" id="cancel-button-acad-course">Cancel</button>
+        <button class="ui green button" id="confirm-button-acad">OK</button>
     </div>
 </div>


### PR DESCRIPTION
…ature and sorted courses

## Issue that this pull request solves

Closes: # (issue number)

## Proposed changes

### restricted the page reload for acad admin drop courses feature and sorted courses by semester id.

## Types of changes

_Put an `x` in the boxes that apply_

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply_

-   [ ] My code follows the [style guidelines of this project](https://docs.google.com/document/d/1GI2Hile8UbGZ82gFe1y4wAVPcNPXip1cmXTzog1S41U/edit)
-   [ ] I have performed a self-review of my own code
-   [ ] I have created new branch for this pull request
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings
-   [ ] My changes does not break the current system and it passes all the current test cases.

## Screenshots

Please attach the screenshots of the changes made in case of change in user interface

## Other information

Any other information that is important to this pull request
