### PR TITLE
Examination: allow acadadmin to submit and upload grades

### DIFF
--- a/FusionIIIT/applications/examination/api/views.py
+++ b/FusionIIIT/applications/examination/api/views.py
@@ -1715,7 +1715,7 @@ class SubmitGradesProfAPI(APIView):
         semester_type = request.data.get("semester_type")
         programme_type = request.data.get("programme_type")
         
-        if not user_holds_any_role(request.user, ["Associate Professor", "Professor", "Assistant Professor"]):
+        if not user_holds_any_role(request.user, ["Associate Professor", "Professor", "Assistant Professor", "acadadmin"]):
             return Response(
                 {"success": False, "error": "Access denied."},
                 status=status.HTTP_403_FORBIDDEN,
@@ -1727,12 +1727,14 @@ class SubmitGradesProfAPI(APIView):
                 status=400,
             )
         
-        instructor_id = request.user.username
-
         working_year, _ = parse_academic_year(academic_year=academic_year, semester_type=semester_type)
 
+        instructor_filter = {"year": working_year, "semester_type": semester_type}
+        if not user_holds_role(request.user, "acadadmin"):
+            instructor_filter["instructor_id_id"] = request.user.username
+
         unique_course_ids = (
-            CourseInstructor.objects.filter(instructor_id_id=instructor_id, year = working_year, semester_type=semester_type)
+            CourseInstructor.objects.filter(**instructor_filter)
             .values("course_id_id")
             .distinct()
             .annotate(course_id_int=Cast("course_id_id", IntegerField()))
@@ -1812,7 +1814,7 @@ class UploadGradesProfAPI(APIView):
         try:
             # 1) ROLE CHECK
             role = request.data.get("Role")
-            if not user_holds_any_role(request.user, ["Associate Professor", "Professor", "Assistant Professor"]):
+            if not user_holds_any_role(request.user, ["Associate Professor", "Professor", "Assistant Professor", "acadadmin"]):
                 return Response({"error": "Access denied."},
                                 status=status.HTTP_403_FORBIDDEN)
 


### PR DESCRIPTION
This pull request updates access control logic in the `FusionIIIT/applications/examination/api/views.py` file to allow users with the `acadadmin` role to access certain endpoints and data, in addition to faculty roles. It also refactors how instructor filtering is handled, ensuring `acadadmin` users can access all relevant courses, while other users are limited to their own.

**Access Control Updates:**

* Added the `acadadmin` role to the allowed roles in access checks, permitting users with this role to access endpoints previously restricted to faculty roles. [[1]](diffhunk://#diff-7f0c0e966e813fb76780cc01a3cfd6e9405eaaa16c6e290c33ed1f09907b7043L1718-R1718) [[2]](diffhunk://#diff-7f0c0e966e813fb76780cc01a3cfd6e9405eaaa16c6e290c33ed1f09907b7043L1815-R1817)

**Data Filtering Logic:**

* Refactored course filtering so that `acadadmin` users can access all courses for a given year and semester, while other users are restricted to courses where they are the instructor. This was achieved by adjusting the filter construction based on the user's role.