### PR TITLE
Restrict acadadmin course access by role and update Summer course lookups

### DIFF
--- a/FusionIIIT/applications/examination/api/views.py
+++ b/FusionIIIT/applications/examination/api/views.py
@@ -1729,7 +1729,8 @@ class SubmitGradesProfAPI(APIView):
         
         working_year, _ = parse_academic_year(academic_year=academic_year, semester_type=semester_type)
 
-        if user_holds_role(request.user, "acadadmin"):
+        acting_as_acadadmin = role == "acadadmin" and user_holds_role(request.user, "acadadmin")
+        if acting_as_acadadmin:
             course_ids = (
                 course_registration.objects
                 .filter(session=academic_year, semester_type=semester_type)
@@ -1966,7 +1967,8 @@ class UploadGradesProfAPI(APIView):
                     )
 
             # 8) INSTRUCTOR‐OWNERSHIP CHECK (acadadmin may submit for any course)
-            if not user_holds_role(request.user, "acadadmin") and not CourseInstructor.objects.filter(
+            acting_as_acadadmin = role == "acadadmin" and user_holds_role(request.user, "acadadmin")
+            if not acting_as_acadadmin and not CourseInstructor.objects.filter(
                 course_id_id=course_id,
                 instructor_id_id=request.user.username,
                 year=working_year

--- a/FusionIIIT/applications/examination/api/views.py
+++ b/FusionIIIT/applications/examination/api/views.py
@@ -227,6 +227,19 @@ def parse_academic_year(academic_year, semester_type):
     session = academic_year  # Use the complete academic year string as session.
     return working_year, session
 
+def course_instructor_year(academic_year, semester_type):
+    """
+    Year used by CourseInstructor rows for a given academic year + semester type.
+    CourseInstructor stores Odd/Summer under the start year and Even under the end
+    year (see CourseInstructor.academic_year). This differs from parse_academic_year,
+    which keys Summer on the end year to match Student_grades — so use this helper
+    (not working_year) whenever filtering CourseInstructor by year.
+    """
+    if semester_type == "Summer Semester":
+        return int(academic_year.split("-")[0].strip())
+    working_year, _ = parse_academic_year(academic_year, semester_type)
+    return working_year
+
 def is_valid_grade(grade: str, course_code: str) -> bool:
     """
     Returns True if the grade is valid for the given course code.
@@ -1741,7 +1754,7 @@ class SubmitGradesProfAPI(APIView):
         else:
             unique_course_ids = (
                 CourseInstructor.objects
-                .filter(instructor_id_id=request.user.username, year=working_year, semester_type=semester_type)
+                .filter(instructor_id_id=request.user.username, year=course_instructor_year(academic_year, semester_type), semester_type=semester_type)
                 .values("course_id_id")
                 .distinct()
                 .annotate(course_id_int=Cast("course_id_id", IntegerField()))
@@ -1971,7 +1984,7 @@ class UploadGradesProfAPI(APIView):
             if not acting_as_acadadmin and not CourseInstructor.objects.filter(
                 course_id_id=course_id,
                 instructor_id_id=request.user.username,
-                year=working_year
+                year=course_instructor_year(academic_year, semester_type)
             ).exists():
                 return Response(
                     {"error": "Access denied: you are not assigned as instructor for this course."},
@@ -2127,7 +2140,7 @@ class DownloadGradesAPI(APIView):
 
             unique_course_ids = (
                 CourseInstructor.objects
-                    .filter(instructor_id_id=instructor_id, year=working_year, semester_type=semester_type)
+                    .filter(instructor_id_id=instructor_id, year=course_instructor_year(academic_year, semester_type), semester_type=semester_type)
                     .values("course_id_id")
                     .distinct()
                     .annotate(course_id_int=Cast("course_id_id", IntegerField()))
@@ -2221,13 +2234,13 @@ class GeneratePDFAPI(APIView):
             if user_holds_role(request.user, "acadadmin"):
                 ci = CourseInstructor.objects.filter(
                     course_id_id=course_id,
-                    year=working_year,
+                    year=course_instructor_year(academic_year, semester_type),
                     semester_type=semester_type,
                 )
             else:
                 ci = CourseInstructor.objects.filter(
                     course_id_id=course_id,
-                    year=working_year,
+                    year=course_instructor_year(academic_year, semester_type),
                     semester_type=semester_type,
                     instructor_id_id=request.user.username
                 )
@@ -3541,7 +3554,7 @@ class GradeStatusAPI(APIView):
             instructors_map = {}
             instructors = CourseInstructor.objects.filter(
                 course_id__in=course_ids,
-                year=working_year,
+                year=course_instructor_year(academic_year, semester_type),
                 semester_type=semester_type
             ).select_related()
             


### PR DESCRIPTION
This pull request updates how the year is determined when querying `CourseInstructor` records, ensuring consistency with how `CourseInstructor` stores Odd/Summer and Even semesters. A new helper function `course_instructor_year` is introduced and used throughout the codebase to prevent mismatches and access errors, especially for instructor-based queries and permission checks.

**Academic year handling improvements:**

* Added the `course_instructor_year` helper function to encapsulate the logic for determining the correct year to use when querying `CourseInstructor` for a given academic year and semester type.
* Updated all queries to `CourseInstructor` in the `post` method and related permission checks to use `course_instructor_year` instead of `working_year`, ensuring instructors are matched to the correct courses and semesters. [[1]](diffhunk://#diff-7f0c0e966e813fb76780cc01a3cfd6e9405eaaa16c6e290c33ed1f09907b7043L1743-R1757) [[2]](diffhunk://#diff-7f0c0e966e813fb76780cc01a3cfd6e9405eaaa16c6e290c33ed1f09907b7043L2128-R2143) [[3]](diffhunk://#diff-7f0c0e966e813fb76780cc01a3cfd6e9405eaaa16c6e290c33ed1f09907b7043L2222-R2243) [[4]](diffhunk://#diff-7f0c0e966e813fb76780cc01a3cfd6e9405eaaa16c6e290c33ed1f09907b7043L3542-R3557) [[5]](diffhunk://#diff-7f0c0e966e813fb76780cc01a3cfd6e9405eaaa16c6e290c33ed1f09907b7043L1969-R1987)

**Role and permission logic:**

* Improved `acadadmin` role checks by introducing the `acting_as_acadadmin` variable, ensuring that admin-specific logic is only applied when the user is actually acting as an academic admin. [[1]](diffhunk://#diff-7f0c0e966e813fb76780cc01a3cfd6e9405eaaa16c6e290c33ed1f09907b7043L1732-R1746) [[2]](diffhunk://#diff-7f0c0e966e813fb76780cc01a3cfd6e9405eaaa16c6e290c33ed1f09907b7043L1969-R1987)