### PR TITLE
Build review-detail media URL from the request instead of a settings value

### DIFF
--- a/FusionIIIT/applications/academic_procedures/api/views.py
+++ b/FusionIIIT/applications/academic_procedures/api/views.py
@@ -7530,7 +7530,7 @@ def review_detail(request, token):
     topic = sub.thesis
 
     if request.method == 'GET':
-        base = getattr(settings, 'SITE_URL', 'http://localhost:8000') + settings.MEDIA_URL
+        base = request.build_absolute_uri(settings.MEDIA_URL)
         return Response({
             'student_name': topic.student.id.user.get_full_name(),
             'student_roll': topic.student.id.id,


### PR DESCRIPTION
## Summary
- Follow-up to #1936. The external-reviewer `review_detail` endpoint was building its media base URL from a `SITE_URL` setting that must be manually kept in sync with the actual deployment domain, and had no such setting defined for this deployment.
- Use `request.build_absolute_uri(settings.MEDIA_URL)` instead, which reflects whatever host the request actually arrived on.

## Test plan
- [ ] Open an external reviewer's review-detail link and confirm the returned media/document URLs resolve correctly against the actual server domain