### PR TITLE
Update seat allocation logic in random_algo for course and programme

### DIFF
--- a/FusionIIIT/applications/academic_information/utils.py
+++ b/FusionIIIT/applications/academic_information/utils.py
@@ -50,7 +50,12 @@ def random_algo(batch,sem,year,course_slot, programme_type) :
     for course in unique_course :
         max_seats[course] = Course.objects.get(id=course).max_seats
         total_seats+=max_seats[course]
-        seats_alloted[course] = 0
+        seats_alloted[course] = FinalRegistration.objects.filter(
+            course_id_id=course,
+            semester_id__semester_no=sem,
+            student_id__batch=batch,
+            student_id__batch_id__curriculum__programme__category=programme_type,
+        ).count()
         present_priority[course] = []
         next_priority[course] = []
 
@@ -86,8 +91,11 @@ def random_algo(batch,sem,year,course_slot, programme_type) :
                         seats_alloted[course] += 1
                         rem-=1
                     else :
-                        next = InitialRegistration.objects.get(Q(student_id__id__id = random_student_selected[0]) & Q( course_slot_id__name = course_slot ) & Q(semester_id__semester_no = sem) & Q(student_id__batch = batch) & Q(priority=p_priority+1) & Q(student_id__batch_id__curriculum__programme__category=programme_type))
-                        next_priority[next.course_id.id].append([next.student_id.id.id,next.course_slot_id.id])
+                        next = InitialRegistration.objects.filter(Q(student_id__id__id = random_student_selected[0]) & Q( course_slot_id__name = course_slot ) & Q(semester_id__semester_no = sem) & Q(student_id__batch = batch) & Q(priority=p_priority+1) & Q(student_id__batch_id__curriculum__programme__category=programme_type)).first()
+                        if next is not None :
+                            next_priority[next.course_id.id].append([next.student_id.id.id,next.course_slot_id.id])
+                        else :
+                            rem-=1
             p_priority+=1
             present_priority = next_priority
             next_priority = {course : [] for course in unique_course}


### PR DESCRIPTION
This pull request updates the seat allocation logic in the `random_algo` function to more accurately track already allotted seats and handle cases where no next priority registration is found. The most important changes are:

**Seat allocation accuracy:**

* The `seats_alloted` dictionary is now initialized with the actual count of `FinalRegistration` entries matching the current course, semester, batch, and programme type, instead of always starting from zero. This ensures that the algorithm accounts for seats already allotted before running.

**Robustness in priority assignment:**

* When searching for the next priority registration, the code now uses `.filter().first()` instead of `.get()`, preventing exceptions if no matching registration is found. If no next registration exists, the remaining seat count (`rem`) is decremented accordingly, ensuring the algorithm doesn't get stuck or raise errors.