### PR TITLE
Credit a retaken course at its best-graded attempt

### DIFF
--- a/FusionIIIT/applications/examination/api/views.py
+++ b/FusionIIIT/applications/examination/api/views.py
@@ -4995,8 +4995,12 @@ class GradeValidationView(APIView):
 
                 cd_rows = []
                 tot_earned = tot_regular = tot_backlog_imp = tot_swayam = 0.0
-                # A course credits the degree once, and a replaced elective not at all.
-                credited_codes = set()
+                # A course credits the degree once, at its best-graded attempt --
+                # the same rule calculate_cpi_for_student uses for the transcript
+                # total. Taking whichever attempt came first instead understated
+                # anyone whose repeated course changed credit between curriculum
+                # versions. A replaced elective credits nothing.
+                credited_by_code = {}
 
                 for gs in graded_sems:
                     earned = regular = backlog_imp = swayam = 0.0
@@ -5032,13 +5036,15 @@ class GradeValidationView(APIView):
                         else:
                             tot_regular += cr
 
-                        # Credits Earned is the degree figure: a course once,
-                        # a replaced one never.
+                        # Credits Earned is the degree figure: a course once, at its
+                        # best-graded attempt, and a replaced one never.
                         code_key = str(c.get("code", "")).strip().upper()
-                        if c.get("superseded") or code_key in credited_codes:
+                        if c.get("superseded"):
                             continue
-                        credited_codes.add(code_key)
-                        tot_earned += cr
+                        kept = credited_by_code.get(code_key)
+                        if kept is None or (grade_conversion.get(g, -1)
+                                            > grade_conversion.get(kept[0], -1)):
+                            credited_by_code[code_key] = (g, cr)
 
                     def _fmt(v): return str(int(v)) if v == int(v) else f"{v:.1f}"
                     cd_rows.append([
@@ -5048,6 +5054,8 @@ class GradeValidationView(APIView):
                         Paragraph(_fmt(backlog_imp), small),
                         Paragraph(_fmt(swayam),      small),
                     ])
+
+                tot_earned = sum(cr for _, cr in credited_by_code.values())
 
                 def _fmt(v): return str(int(v)) if v == int(v) else f"{v:.1f}"
 


### PR DESCRIPTION
Follow-up to #1953. One file, one rule.

## The problem

Three places reported different credit totals for the same student. For
a roll number the grade-validation PDF said 126 and the transcript said 127.

The Credits Details block totalled a repeated course at whichever attempt
came *first*, while `calculate_cpi_for_student` — the source of truth the
transcript prints — takes the best-graded attempt via its `best_by_code`
dedup. The two agree right up until the same course code exists at two
credit values across curriculum versions. SM2007 was worth 3 credits when
he scored D and 4 credits when he cleared it, so the first-attempt rule
banked the 3.

## The fix

`tot_earned` now keeps, per course code, the attempt with the better grade,
ordered by the existing `grade_conversion` map — the same ordering
`calculate_cpi_for_student` already uses. A course still counts once, and a
superseded elective still counts never.

Paired with FusionIIIT/Fusion-client#290 so the frontend summary matches.

## Verification

Ran `calculate_cpi_for_student` against a local copy of the production
database for a roll number: Credits Details and the transcript now both report
127.
