### PR TITLE
Open the student-admission screens to the programme roles, and fix two announcement holes

### DIFF
--- a/FusionIIIT/applications/examination/api/views.py
+++ b/FusionIIIT/applications/examination/api/views.py
@@ -15,6 +15,7 @@ from applications.examination.models import(hidden_grades , ResultAnnouncement, 
 from applications.globals.access import user_holds_role, user_holds_any_role
 from applications.globals.programme_scope import (
     ALL_ACAD_ROLES,
+    PROGRAMME_NAMES_BY_SCOPE,
     batch_in_scope,
     roll_scope_sql,
     scope_allows,
@@ -85,12 +86,7 @@ PBI_AND_BTP_ALLOWED_GRADES = {
 }
 
 PROGRAMME_TYPE_BUCKETS = {
-    'UG': ['B.Tech', 'B.Des'],
-    'PG': ['M.Tech', 'M.Des'],
-    # Student.programme is declared as 'PhD' in academic_information.Constants.PROGRAMME,
-    # but the PhD student-promotion flow (programme_curriculum) actually writes 'Ph.D' —
-    # accept both so this doesn't silently return zero PhD students.
-    'PHD': ['PhD', 'Ph.D'],
+    scope: list(names) for scope, names in PROGRAMME_NAMES_BY_SCOPE.items()
 }
 
 

--- a/FusionIIIT/applications/globals/api/views.py
+++ b/FusionIIIT/applications/globals/api/views.py
@@ -39,6 +39,7 @@ from applications.globals.decorators import role_required
 from applications.globals.programme_scope import (
     ALL_ACAD_ROLES,
     STUDENT_CATEGORY_PATH,
+    scope_recipients,
     scopes_for,
 )
 _security_log = logging.getLogger("fusion.security")
@@ -544,10 +545,7 @@ def create_announcement(request):
 
     announcement = serializer.save(created_by=request.user.extrainfo)
 
-    recipients = resolve_audience_recipients(announcement)
-    if scopes is not None:
-        recipients = recipients.filter(**{
-            'extrainfo__student__' + STUDENT_CATEGORY_PATH + '__in': scopes})
+    recipients = scope_recipients(resolve_audience_recipients(announcement), scopes)
     notify.send(
         sender=request.user,
         recipient=recipients,
@@ -565,7 +563,7 @@ def create_announcement(request):
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 @authentication_classes([TokenAuthentication])
-@role_required(['acadadmin'])
+@role_required(list(ALL_ACAD_ROLES))
 def announcement_audience_options(request):
     roles = serializers.DesignationSerializer(Designation.objects.all(), many=True).data
     departments = serializers.DepartmentInfoSerializer(DepartmentInfo.objects.all(), many=True).data
@@ -575,17 +573,22 @@ def announcement_audience_options(request):
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 @authentication_classes([TokenAuthentication])
-@role_required(['acadadmin'])
+@role_required(list(ALL_ACAD_ROLES))
 def search_users(request):
     query = request.query_params.get('q', '').strip()
     if not query:
         return Response([], status=status.HTTP_200_OK)
 
-    users = User.objects.filter(
-        Q(username__icontains=query)
-        | Q(first_name__icontains=query)
-        | Q(last_name__icontains=query)
-        | Q(extrainfo__id__icontains=query)
+    # scoped before the slice, so a programme admin cannot pick a student whose
+    # notification would then be dropped on send
+    users = scope_recipients(
+        User.objects.filter(
+            Q(username__icontains=query)
+            | Q(first_name__icontains=query)
+            | Q(last_name__icontains=query)
+            | Q(extrainfo__id__icontains=query)
+        ),
+        scopes_for(request.user),
     ).distinct()[:20]
 
     results = [

--- a/FusionIIIT/applications/globals/programme_scope.py
+++ b/FusionIIIT/applications/globals/programme_scope.py
@@ -6,6 +6,8 @@ reach must narrow its data to that category. A view that is not scoped yet stays
 closed to them, which costs them the feature but never leaks another
 programme's students.
 """
+from django.db.models import Q
+
 from applications.globals.models import HoldsDesignation
 
 SCOPE_BY_ROLE = {
@@ -21,6 +23,18 @@ SCOPED_ACAD_ROLES = tuple(SCOPE_BY_ROLE)
 ALL_ACAD_ROLES = UNSCOPED_ACAD_ROLES + SCOPED_ACAD_ROLES
 
 STUDENT_CATEGORY_PATH = "batch_id__curriculum__programme__category"
+
+# Programme names as they are stored on Student.programme and on
+# BatchConfiguration.programme. The PhD promotion flow writes 'Ph.D' while
+# academic_information.Constants declares 'PhD', so both spellings count.
+PROGRAMME_NAMES_BY_SCOPE = {
+    "UG": ("B.Tech", "B.Des"),
+    "PG": ("M.Tech", "M.Des"),
+    "PHD": ("PhD", "Ph.D"),
+}
+
+# 'ug' / 'pg' / 'phd' as the admission-record models spell it
+ADMISSION_TYPE_BY_SCOPE = {"UG": "ug", "PG": "pg", "PHD": "phd"}
 
 
 def _role_names(user):
@@ -117,15 +131,68 @@ def scoped_ids(model, ids, scopes, student_path="student"):
     return list(allowed.values_list("id", flat=True))
 
 
-def scope_admission_records(queryset, scopes):
-    """Narrow StudentBatchUpload rows, whose own programme_type is 'ug'/'pg'."""
+def programme_names_for(scopes):
+    """Programme names inside ``scopes``, or None when nothing is excluded."""
+    if scopes is None:
+        return None
+    names = []
+    for scope in scopes:
+        names.extend(PROGRAMME_NAMES_BY_SCOPE.get(scope, ()))
+    return tuple(names)
+
+
+def programme_name_in_scope(name, scopes):
+    if scopes is None:
+        return True
+    return (name or "") in programme_names_for(scopes)
+
+
+def scope_by_programme_name(queryset, scopes, field="programme"):
+    """Narrow rows that name their programme, such as BatchConfiguration."""
     if scopes is None:
         return queryset
-    wanted = [s for s in scopes if s in ("UG", "PG")]
-    if not wanted:
+    names = programme_names_for(scopes)
+    if not names:
         return queryset.none()
-    values = [s.lower() for s in wanted] + [s.upper() for s in wanted]
+    return queryset.filter(**{"%s__in" % field: names})
+
+
+def admission_type_in_scope(programme_type, scopes):
+    """For the 'ug'/'pg'/'phd' programme_type the admission models carry."""
+    if scopes is None:
+        return True
+    wanted = (programme_type or "").strip().lower()
+    return wanted in {ADMISSION_TYPE_BY_SCOPE[s] for s in scopes
+                      if s in ADMISSION_TYPE_BY_SCOPE}
+
+
+def scope_admission_records(queryset, scopes):
+    """Narrow admission records. StudentBatchUpload names its own programme_type
+    ('ug'/'pg'); PhdStudentBatchUpload has no such field and is PhD by model."""
+    if scopes is None:
+        return queryset
+    field_names = {f.name for f in queryset.model._meta.fields}
+    if "programme_type" not in field_names:
+        return queryset if "PHD" in scopes else queryset.none()
+    values = []
+    for scope in scopes:
+        spelling = ADMISSION_TYPE_BY_SCOPE.get(scope)
+        if spelling:
+            values.extend([spelling, spelling.upper()])
+    if not values:
+        return queryset.none()
     return queryset.filter(programme_type__in=values)
+
+
+def scope_recipients(users, scopes):
+    """Drop students outside the scope. Faculty and staff are not bound to a
+    programme, so they stay: a role-targeted announcement still reaches them."""
+    if scopes is None:
+        return users
+    return users.filter(
+        Q(**{"extrainfo__student__" + STUDENT_CATEGORY_PATH + "__in": scopes})
+        | Q(extrainfo__student__isnull=True)
+    )
 
 
 def allows_phd(scopes):

--- a/FusionIIIT/applications/programme_curriculum/api/views_student_management.py
+++ b/FusionIIIT/applications/programme_curriculum/api/views_student_management.py
@@ -258,12 +258,29 @@ def normalize_category(value, is_phd=False):
 
 from applications.globals.programme_scope import (
     ALL_ACAD_ROLES,
+    SCOPED_ACAD_ROLES,
     admission_record_in_scope,
+    admission_type_in_scope,
     batch_in_scope,
+    programme_name_in_scope,
+    scope_admission_records,
     scope_batches,
+    scope_by_programme_name,
+    scope_curriculums,
     scope_students,
     scopes_for,
 )
+
+# The programme roles administer these student/admission screens for their own
+# level; every view below narrows its rows to that level.
+STUDENT_ADMIN_ROLES = ("acadadmin", "Dean Academic") + SCOPED_ACAD_ROLES
+
+
+def _out_of_scope(what="record"):
+    return JsonResponse(
+        {'success': False, 'message': 'You do not administer this %s.' % what},
+        status=403,
+    )
 from .account_sync import (
     admission_category,
     reservation_category,
@@ -534,7 +551,7 @@ def get_display_branch_name(discipline):
 
 @csrf_exempt
 @require_http_methods(["POST"])
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 def process_excel_upload(request):
     try:
         if 'file' not in request.FILES:
@@ -545,6 +562,8 @@ def process_excel_upload(request):
         
         file = request.FILES['file']
         programme_type = request.POST.get('programme_type', 'ug')
+        if not admission_type_in_scope(programme_type, scopes_for(request.user)):
+            return _out_of_scope('programme')
         
         year_result = validate_and_normalize_year(request.POST.get('academic_year'))
         if isinstance(year_result, JsonResponse):
@@ -841,12 +860,14 @@ def check_student_duplicate(student, duplicate_check_fields, programme_type='ug'
 
 @csrf_exempt
 @require_http_methods(["POST"])
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 def save_students_batch(request):
     try:
         data = json.loads(request.body)
         students = data.get('students', [])
         programme_type = data.get('programme_type', 'ug')
+        if not admission_type_in_scope(programme_type, scopes_for(request.user)):
+            return _out_of_scope('programme')
         phd_semester = data.get('phd_semester', None)  # Get PhD semester (odd/even)
         year_result = validate_and_normalize_year(data.get('academic_year'))
         if isinstance(year_result, JsonResponse):
@@ -1272,11 +1293,13 @@ def get_allocation_summary(students, programme_type):
 
 @csrf_exempt
 @require_http_methods(["POST"])
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 def add_single_student(request):
     try:
         data = json.loads(request.body)
         programme_type = data.get('programme_type', 'ug')
+        if not admission_type_in_scope(programme_type, scopes_for(request.user)):
+            return _out_of_scope('programme')
         phd_semester = data.get('phd_semester', None)  # Get PhD semester (odd/even)
         
         year_result = validate_and_normalize_year(data.get('academic_year'))
@@ -1515,7 +1538,7 @@ def add_single_student(request):
 
 @csrf_exempt
 @require_http_methods(["PUT"])
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 def set_total_seats(request):
     try:
         data = json.loads(request.body)
@@ -1530,6 +1553,9 @@ def set_total_seats(request):
                 'success': False,
                 'message': 'Missing required fields: programme, discipline, year, total_seats'
             }, status=400)
+
+        if not programme_name_in_scope(programme, scopes_for(request.user)):
+            return _out_of_scope('programme')
 
         batch_config, created = BatchConfiguration.objects.update_or_create(
             programme=programme,
@@ -1563,7 +1589,7 @@ def set_total_seats(request):
 # STUDENT STATUS MANAGEMENT
 # =============================================================================
 
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 @csrf_exempt
 @require_http_methods(["PUT", "POST", "OPTIONS"])
 def update_student_status(request):
@@ -1624,6 +1650,8 @@ def update_student_status(request):
                     }, status=404)
         
         old_status = student.reported_status
+        if not admission_record_in_scope(student, scopes_for(request.user)):
+            return _out_of_scope('student')
         student.reported_status = reported_status
         student.save()
         
@@ -2407,7 +2435,7 @@ def update_student_status(request):
 # EXPORT FUNCTIONALITY
 # =============================================================================
 
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 @csrf_exempt
 @require_http_methods(["GET"])
 def export_students(request, programme_type):
@@ -2415,7 +2443,11 @@ def export_students(request, programme_type):
     Export student data to Excel
     """
     try:
-        students = StudentBatchUpload.objects.filter(programme_type=programme_type).order_by('roll_number')
+        if not admission_type_in_scope(programme_type, scopes_for(request.user)):
+            return _out_of_scope('programme')
+        students = scope_admission_records(
+            StudentBatchUpload.objects.filter(programme_type=programme_type),
+            scopes_for(request.user)).order_by('roll_number')
         
         if not students.exists():
             return JsonResponse({
@@ -2496,7 +2528,7 @@ def export_students(request, programme_type):
 # UPLOAD HISTORY
 # =============================================================================
 
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 @csrf_exempt
 @require_http_methods(["GET"])
 def upload_history(request):
@@ -2506,7 +2538,9 @@ def upload_history(request):
     try:
         from django.db.models import Count
         
-        history = StudentBatchUpload.objects.values('created_at__date', 'programme_type').annotate(
+        history = scope_admission_records(
+            StudentBatchUpload.objects.all(), scopes_for(request.user)
+        ).values('created_at__date', 'programme_type').annotate(
             count=Count('id')
         ).order_by('-created_at__date')
         
@@ -2526,7 +2560,7 @@ def upload_history(request):
 # STUDENT LISTING
 # =============================================================================
 
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 @csrf_exempt
 @require_http_methods(["GET"])
 def list_students(request):
@@ -2540,7 +2574,8 @@ def list_students(request):
         discipline = request.GET.get('discipline')
         specialization = request.GET.get('specialization')
         
-        students = StudentBatchUpload.objects.all()
+        students = scope_admission_records(
+            StudentBatchUpload.objects.all(), scopes_for(request.user))
         
         if programme_type:
             students = students.filter(programme_type=programme_type)
@@ -2644,7 +2679,7 @@ def list_students(request):
 
 @csrf_exempt
 @require_http_methods(["POST"])
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 def create_batch(request):
     """
     Create new batch
@@ -2680,6 +2715,9 @@ def create_batch(request):
                 'success': False,
                 'message': f'Missing required fields: {", ".join(missing_fields)}'
             }, status=400)
+
+        if not programme_name_in_scope(programme, scopes_for(request.user)):
+            return _out_of_scope('programme')
 
         from applications.programme_curriculum.models import Curriculum
 
@@ -2796,7 +2834,7 @@ def create_batch(request):
             'message': f'Failed to create batch: {str(e)}'
         }, status=500)
 
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 @csrf_exempt
 @require_http_methods(["PUT"])
 def update_batch(request, batch_id):
@@ -2830,6 +2868,13 @@ def update_batch(request, batch_id):
                     'success': False,
                     'message': f'Batch with ID {batch_id} not found in any model'
                 }, status=404)
+
+        scopes = scopes_for(request.user)
+        # both the batch as it stands and the programme it is being moved to
+        if not programme_name_in_scope(batch.programme, scopes):
+            return _out_of_scope('batch')
+        if 'programme' in data and not programme_name_in_scope(data['programme'], scopes):
+            return _out_of_scope('programme')
 
         # Update fields
         if 'programme' in data:
@@ -2866,7 +2911,7 @@ def update_batch(request, batch_id):
         }, status=500)
 
 
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 @csrf_exempt
 @require_http_methods(["GET"])
 def list_batches_with_status(request):
@@ -2874,7 +2919,9 @@ def list_batches_with_status(request):
     List all batches with status
     """
     try:
-        batches = BatchConfiguration.objects.all().order_by('programme', 'discipline', 'year')
+        batches = scope_by_programme_name(
+            BatchConfiguration.objects.all(), scopes_for(request.user)
+        ).order_by('programme', 'discipline', 'year')
         
         batch_list = []
         for batch in batches:
@@ -2904,7 +2951,7 @@ def list_batches_with_status(request):
 # STUDENT STATUS CRUD
 # =============================================================================
 
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 @csrf_exempt
 @require_http_methods(["PUT"])
 def update_student_status_crud(request, student_id):
@@ -2923,6 +2970,8 @@ def update_student_status_crud(request, student_id):
         
         try:
             student = StudentBatchUpload.objects.get(id=student_id)
+            if not admission_record_in_scope(student, scopes_for(request.user)):
+                return _out_of_scope('student')
         except StudentBatchUpload.DoesNotExist:
             return JsonResponse({
                 'success': False,
@@ -2976,7 +3025,7 @@ def update_student_status_crud(request, student_id):
 # PASSWORD MANAGEMENT
 # =============================================================================
 
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 @csrf_exempt
 @require_http_methods(["POST"])
 def auto_generate_passwords_for_batch(request):
@@ -3001,10 +3050,14 @@ def auto_generate_passwords_for_batch(request):
                 'message': 'Batch not found'
             }, status=404)
         
-        students = StudentBatchUpload.objects.filter(
+        scopes = scopes_for(request.user)
+        if not programme_name_in_scope(batch.programme, scopes):
+            return _out_of_scope('batch')
+
+        students = scope_admission_records(StudentBatchUpload.objects.filter(
             branch__icontains=batch.discipline,
             year=batch.year
-        )
+        ), scopes)
         
         updated_count = 0
         for student in students:
@@ -3490,7 +3543,7 @@ def create_or_update_main_student_record(student_data, batch_obj, batch_year):
 # INDIVIDUAL STUDENT CRUD OPERATIONS
 # =============================================================================
 
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 @csrf_exempt
 @require_http_methods(["GET"])
 def get_student(request, student_id):
@@ -3499,6 +3552,8 @@ def get_student(request, student_id):
     """
     try:
         student = StudentBatchUpload.objects.get(id=student_id)
+        if not admission_record_in_scope(student, scopes_for(request.user)):
+            return _out_of_scope('student')
 
         student_data = {
             # Core identification
@@ -3939,7 +3994,7 @@ def update_student(request, student_id):
         }, status=500)
 
 
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 @csrf_exempt
 @require_http_methods(["DELETE", "POST"])
 def delete_student(request, student_id):
@@ -3980,6 +4035,8 @@ def delete_student(request, student_id):
                     return JsonResponse({'success': False,
                         'message': f'Student with ID {student_id} not found'}, status=404)
         student_name = student.name
+        if not admission_record_in_scope(student, scopes_for(request.user)):
+            return _out_of_scope('student')
         student_roll = student.roll_number
 
         deletion_info = {
@@ -4097,7 +4154,7 @@ def delete_student(request, student_id):
 # BULK STATUS UPDATE FUNCTIONALITY  
 # =============================================================================
 
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 @csrf_exempt
 @require_http_methods(["POST"])
 def bulk_update_student_status(request):
@@ -4131,7 +4188,29 @@ def bulk_update_student_status(request):
         success_count = 0
         error_count = 0
         curriculum_assignments = {}
-        
+
+        # Each id is delegated to update_student_status, which guards its own
+        # scope; naming the out-of-scope ones here keeps the summary honest.
+        scopes = scopes_for(request.user)
+        if scopes is not None:
+            # PhD records live in their own table with their own ids, so only
+            # ids known to be UG/PG are judged here; the rest are left to the
+            # per-student call, which guards itself.
+            known = StudentBatchUpload.objects.filter(id__in=student_ids)
+            known_ids = set(known.values_list('id', flat=True))
+            allowed = set(scope_admission_records(known, scopes)
+                          .values_list('id', flat=True))
+            refused = [sid for sid in student_ids
+                       if sid in known_ids and sid not in allowed]
+            for sid in refused:
+                error_count += 1
+                results.append({
+                    'student_id': sid,
+                    'status': 'error',
+                    'message': 'You do not administer this student.',
+                })
+            student_ids = [sid for sid in student_ids if sid not in refused]
+
         for student_id in student_ids:
             try:
                 # USE DATABASE TRANSACTION ISOLATION FOR EACH STUDENT
@@ -4813,7 +4892,7 @@ def admin_batches_unified(request):
         }, status=500)
 
 
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 @csrf_exempt
 @require_http_methods(["GET"])
 def sync_batch_data(request):
@@ -4825,7 +4904,9 @@ def sync_batch_data(request):
         from applications.programme_curriculum.models import Batch
         from applications.academic_information.models import Student
 
-        all_batches = Batch.objects.filter(running_batch=True).select_related(
+        all_batches = scope_batches(
+            Batch.objects.filter(running_batch=True), scopes_for(request.user)
+        ).select_related(
             'discipline', 'curriculum'
         ).order_by('year', 'discipline__name')
         
@@ -4891,7 +4972,7 @@ def sync_batch_data(request):
         }, status=500)
 
 
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 @csrf_exempt
 @require_http_methods(["POST"])
 def validate_batch_prerequisites(request):
@@ -4934,11 +5015,11 @@ def validate_batch_prerequisites(request):
             try:
                 discipline = Discipline.objects.filter(name__iexact=discipline_name).first()
                 if discipline:
-                    batch = Batch.objects.filter(
+                    batch = scope_batches(Batch.objects.filter(
                         year=academic_year,
                         discipline=discipline,
                         running_batch=True
-                    ).first()
+                    ), scopes_for(request.user)).first()
                     
                     if batch:
                         existing_batches.append({
@@ -4987,7 +5068,7 @@ def validate_batch_prerequisites(request):
 # BATCH CURRICULUM STATUS CHECK
 # =============================================================================
 
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 @csrf_exempt
 @require_http_methods(["GET"])
 def check_batches_curriculum_status(request):
@@ -4999,7 +5080,9 @@ def check_batches_curriculum_status(request):
     try:
         from applications.programme_curriculum.models import Batch
 
-        batches = Batch.objects.filter(running_batch=True).select_related(
+        batches = scope_batches(
+            Batch.objects.filter(running_batch=True), scopes_for(request.user)
+        ).select_related(
             'discipline', 'curriculum'
         ).order_by('-year', 'discipline__name')
         
@@ -5059,7 +5142,7 @@ def check_batches_curriculum_status(request):
         }, status=500)
 
 
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 @csrf_exempt
 @require_http_methods(["GET"])
 def validate_student_upload_prerequisites(request):
@@ -5082,7 +5165,8 @@ def validate_student_upload_prerequisites(request):
         
         from applications.programme_curriculum.models import Curriculum, Batch
 
-        available_curriculums = Curriculum.objects.filter(working_curriculum=True)
+        available_curriculums = scope_curriculums(
+            Curriculum.objects.filter(working_curriculum=True), scopes_for(request.user))
         curriculum_check = {
             'exists': available_curriculums.exists(),
             'count': available_curriculums.count(),
@@ -5091,7 +5175,9 @@ def validate_student_upload_prerequisites(request):
                       else 'No working curriculums found - please create curriculums first'
         }
 
-        existing_batches = Batch.objects.filter(year=batch_year, running_batch=True)
+        existing_batches = scope_batches(
+            Batch.objects.filter(year=batch_year, running_batch=True),
+            scopes_for(request.user))
         batch_check = {
             'exists': existing_batches.exists(),
             'count': existing_batches.count(),
@@ -5153,7 +5239,7 @@ def validate_student_upload_prerequisites(request):
 # CURRICULUM REDUNDANCY CLEANUP UTILITIES
 # =============================================================================
 
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 @csrf_exempt
 @require_http_methods(["GET"])
 def find_duplicate_curriculums(request):
@@ -5165,7 +5251,7 @@ def find_duplicate_curriculums(request):
         from applications.programme_curriculum.models import Curriculum
         from django.db.models import Count
 
-        duplicates = (Curriculum.objects
+        duplicates = (scope_curriculums(Curriculum.objects.all(), scopes_for(request.user))
                      .values('name', 'programme__name', 'programme__id')
                      .annotate(count=Count('id'))
                      .filter(count__gt=1, working_curriculum=True)
@@ -5178,11 +5264,11 @@ def find_duplicate_curriculums(request):
             programme_id = dup['programme__id']
             count = dup['count']
 
-            curricula = Curriculum.objects.filter(
+            curricula = scope_curriculums(Curriculum.objects.filter(
                 name=curriculum_name,
                 programme__id=programme_id,
                 working_curriculum=True
-            ).order_by('version')
+            ), scopes_for(request.user)).order_by('version')
             
             curriculum_list = []
             for curr in curricula:
@@ -5216,7 +5302,7 @@ def find_duplicate_curriculums(request):
         }, status=500)
 
 
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 @csrf_exempt
 @require_http_methods(["POST"])
 def consolidate_duplicate_curriculums(request):
@@ -5246,11 +5332,16 @@ def consolidate_duplicate_curriculums(request):
                 'message': f'Curriculum with ID {keep_curriculum_id} not found'
             }, status=400)
 
-        duplicate_curriculums = Curriculum.objects.filter(
+        scopes = scopes_for(request.user)
+        if not scope_curriculums(
+                Curriculum.objects.filter(id=keep_curriculum.id), scopes).exists():
+            return _out_of_scope('curriculum')
+
+        duplicate_curriculums = scope_curriculums(Curriculum.objects.filter(
             name=curriculum_name,
             programme__id=programme_id,
             working_curriculum=True
-        ).exclude(id=keep_curriculum_id)
+        ), scopes).exclude(id=keep_curriculum_id)
 
         reassigned_batches = 0
         for dup_curriculum in duplicate_curriculums:
@@ -5289,7 +5380,7 @@ def consolidate_duplicate_curriculums(request):
 # BATCH REDUNDANCY CLEANUP UTILITIES
 # =============================================================================
 
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 @csrf_exempt
 @require_http_methods(["GET"])
 def find_duplicate_batches(request):
@@ -5301,7 +5392,7 @@ def find_duplicate_batches(request):
         from applications.programme_curriculum.models import Batch
         from django.db.models import Count
 
-        duplicates = (Batch.objects
+        duplicates = (scope_batches(Batch.objects.all(), scopes_for(request.user))
                      .values('name', 'discipline__name', 'discipline__acronym', 'discipline__id', 'year')
                      .annotate(count=Count('id'))
                      .filter(count__gt=1, running_batch=True)
@@ -5365,7 +5456,7 @@ def find_duplicate_batches(request):
         }, status=500)
 
 
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 @csrf_exempt
 @require_http_methods(["POST"])
 def consolidate_duplicate_batches(request):
@@ -5396,12 +5487,16 @@ def consolidate_duplicate_batches(request):
                 'message': f'Batch with ID {keep_batch_id} not found'
             }, status=400)
 
-        duplicate_batches = Batch.objects.filter(
+        scopes = scopes_for(request.user)
+        if not batch_in_scope(keep_batch, scopes):
+            return _out_of_scope('batch')
+
+        duplicate_batches = scope_batches(Batch.objects.filter(
             name=programme_name,
             discipline__id=discipline_id,
             year=year,
             running_batch=True
-        ).exclude(id=keep_batch_id)
+        ), scopes).exclude(id=keep_batch_id)
 
         reassigned_students = 0
         total_seats_added = 0
@@ -5452,7 +5547,7 @@ def consolidate_duplicate_batches(request):
         }, status=500)
 
 
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 @csrf_exempt
 @require_http_methods(["POST"])
 def fix_stuck_reported_students(request):
@@ -5460,7 +5555,8 @@ def fix_stuck_reported_students(request):
     Fix students that are stuck in REPORTED status and should be transferred to academic system
     """
     try:
-        stuck_students = StudentBatchUpload.objects.filter(
+        stuck_students = scope_admission_records(
+            StudentBatchUpload.objects.all(), scopes_for(request.user)).filter(
             reported_status='REPORTED'
         ).exclude(
             Q(first_name__isnull=True) | Q(first_name='') |
@@ -5612,7 +5708,7 @@ def transfer_student_to_academic_system(student):
         }
 
 
-@require_designation("acadadmin", "Dean Academic")
+@require_designation(*STUDENT_ADMIN_ROLES)
 @csrf_exempt
 @require_http_methods(["POST"])
 def sync_batches_to_configuration(request):
@@ -5627,7 +5723,7 @@ def sync_batches_to_configuration(request):
         created_count = 0
         updated_count = 0
         
-        for batch in Batch.objects.all():
+        for batch in scope_batches(Batch.objects.all(), scopes_for(request.user)):
             # Check if BatchConfiguration already exists with this ID
             try:
                 batch_config = BatchConfiguration.objects.get(id=batch.id)


### PR DESCRIPTION
Follow-up to #1957. Checking the three roles against a copy of production turned up three gaps that pass left behind.

## A role-targeted announcement reached nobody

The recipient filter required every recipient to be a student of the sender's programme, so faculty failed it. An Acad UG announcement to `Professor` was created and notified **0** people where `acadadmin` notified 11 — the announcement row existed and nobody heard about it.

`scope_recipients()` now drops out-of-scope *students* and keeps anyone who is not a student, since faculty and staff are not programme-bound.

| audience, as Acad UG | before | after | acadadmin |
|---|---|---|---|
| programme UG | 2971 | 2971 | 2971 |
| programme PG | 403 refused | 403 refused | 135 |
| role Professor | **0** | **11** | 11 |
| everyone | 2971 | 3232 | 3368 |

The 136 users dropped from "everyone" are exactly the 135 PG students plus one student with no batch.

## The compose helpers were still acadadmin-only

`announcement_audience_options` and `search_users` both returned **403** to all three roles, so they could submit an announcement through the API but could not open the form that builds one. Both now accept them, and the recipient search is scoped *before* its `[:20]` slice — Acad UG searching `25MCSA` gets 0 hits, Acad PG gets 20 — so a programme admin cannot pick a student whose notification would then be dropped on send.

## The 26 student-admission views were closed, leaving a 403 behind a sidebar entry

`adminUpcomingBatches` is in the three roles' nav, but `list_students` and 25 sibling views in `views_student_management.py` were gated to `acadadmin`/`Dean Academic`. All 26 are now open **and** scoped:

- lists, exports and upload history narrow to the role's own level
- per-record reads and writes refuse a record from another level
- create / upload / seat-configuration paths validate the programme they are asked to act on
- consolidating duplicate curriculums or batches is confined to in-scope records, so a programme admin cannot merge another level's data away
- the bulk status update names the ids it refuses rather than skipping them silently, and only judges ids from the UG/PG table — PhD records have their own id space, and the per-student call guards itself

The gate is `("acadadmin", "Dean Academic") + SCOPED_ACAD_ROLES`, deliberately not `ALL_ACAD_ROLES`, which would also have admitted `studentacadadmin` — a role that never had access here.

### Verified against production-shaped data

| endpoint | Acad UG | Acad PG | Acad Ph.D. | acadadmin |
|---|---|---|---|---|
| `list_students` | 611 | 144 | 0 | **755** |
| `upload_history` | 2 | 2 | 0 | **4** |
| `sync_batch_data` | 30 | 13 | 0 | **43** |
| `batches/curriculum_status` | 30 | 13 | 0 | **43** |
| `find_duplicate_curriculums` | 5 | 5 | 0 | **10** |
| `download_students/ug/` | 150 KB | 403 | 403 | 150 KB |
| `download_students/pg/` | 403 | 37 KB | 403 | 37 KB |

Every partition sums to the unscoped total. On the write side, against a real PG record: `get_student` / `update_student_status` / `delete_student` refuse Acad UG with 403 and succeed for Acad PG; `add_single_student(pg)`, `save_students_batch(pg)`, `process_excel_upload(pg)`, `create_batch(M.Tech)` and `set_total_seats(M.Tech)` refuse Acad UG while Acad PG passes the gate and fails only on its own field validation; consolidation refuses Acad UG for both a PG curriculum and a PG batch; a bulk update over one PG and one UG id gives Acad UG "1 successful, 1 failed" against acadadmin's "2 successful, 0 failed". Every write ran inside a rolled-back transaction, so the database is untouched.

## Two helpers were wrong rather than missing

`scope_admission_records` filtered on `programme_type`, a field only the UG/PG model has, so it would have raised `FieldError` on PhD records; it now falls back to "PhD by model". The programme-name table (`B.Tech`/`M.Tech`/`PhD`) existed twice, here and in `examination`; it now lives once in `programme_scope`. Examination's numbers are unchanged after that dedupe: grade summary 202/21/0/211, grade status 209/22/0/219.

## Pre-existing failures found, not touched

Each fails identically for `acadadmin` with the same payload, so they predate this branch: `create_batch` → 500 `Field 'id' expected a number`; `sync_batches_to_configuration` → 500 duplicate key; `fix_stuck_reported_students` → 500 `Cannot resolve keyword 'first_name'`, a field that model does not have — that view cannot ever have worked.

`manage.py check` clean, no missing migrations, no new migrations needed.