### PR TITLE
Open pre-registration for the first UG semester, and name the calendar event a window needs

### DIFF
--- a/FusionIIIT/applications/academic_procedures/api/views.py
+++ b/FusionIIIT/applications/academic_procedures/api/views.py
@@ -2896,7 +2896,14 @@ def _check_registration_window(description, action_label):
     try:
         event = Calendar.objects.get(description=description)
     except Calendar.DoesNotExist:
-        return JsonResponse({"error": f"{action_label} date is not yet decided"}, status=400)
+        # Name the event that is missing: the window is keyed by an exact
+        # calendar description, and "not yet decided" gave the office no way to
+        # tell a missing event from one entered under another name.
+        return JsonResponse({
+            "error": f"{action_label} date is not yet decided",
+            "detail": f"No academic calendar event named \"{description}\".",
+            "expected_event": description,
+        }, status=400)
     start, end = _calendar_window_bounds(event)
     now = datetime.datetime.now()
     if now < start:
@@ -2914,7 +2921,16 @@ def get_drop_registration_eligibility(current_date, user_sem, year = datetime.da
 def get_replace_registration_eligibility(current_date, user_sem, year = datetime.datetime.now().year):
     return _check_registration_window(f"Replace {user_sem} {year}", "Replace course")
 
-def get_pre_registration_eligibility(current_date, user_sem, year = datetime.datetime.now().year):
+def get_pre_registration_eligibility(current_date, user_sem, year = datetime.datetime.now().year,
+                                     student=None):
+    # Pre-registration is keyed by the semester being registered into, so a UG
+    # student in semester 1 needs "Pre Registration 2". The office opens that
+    # first cohort separately, so "Pre Registration 0" is accepted for them and
+    # takes precedence when it exists.
+    if student is not None and user_sem == 2 and _is_ug_student(student):
+        first_sem_event = f"Pre Registration 0 {year}"
+        if Calendar.objects.filter(description=first_sem_event).exists():
+            return _check_registration_window(first_sem_event, "Pre Registration")
     return _check_registration_window(f"Pre Registration {user_sem} {year}", "Pre Registration")
 
 def get_swayam_registration_eligibility(current_date, user_sem, year = datetime.datetime.now().year):
@@ -3029,7 +3045,8 @@ def get_preregistration_data(request):
             return JsonResponse({"message": "Already registered", "data": data, "backlog_data":backlog_data}, safe=False)
         else:
             # If not already registered, return slots without pre-set priorities.
-            eligibility_resp = get_pre_registration_eligibility(timezone.now().date(), next_sem_no)
+            eligibility_resp = get_pre_registration_eligibility(
+                timezone.now().date(), next_sem_no, student=student)
             if isinstance(eligibility_resp, JsonResponse):
                 return eligibility_resp
             prev_registrations = serializers.CourseRegistrationSerializer(course_registration.objects.filter(student_id=student), many=True).data
@@ -3092,7 +3109,8 @@ def submit_preregistration(request):
             next_semester = Semester.objects.get(curriculum=student.batch_id.curriculum, semester_no=next_sem_no)
         except Semester.DoesNotExist:
             return JsonResponse({"error": "Not Eligible for Pre Registration"}, status=400)
-        eligibility_resp = get_pre_registration_eligibility(timezone.now().date(), next_sem_no)
+        eligibility_resp = get_pre_registration_eligibility(
+            timezone.now().date(), next_sem_no, student=student)
         if isinstance(eligibility_resp, JsonResponse):
             return eligibility_resp
     except Student.DoesNotExist:
@@ -8786,6 +8804,13 @@ def _resolve_discipline_matched_entry(manager, student):
 
 def _catalog_entry_to_dict(entry):
     return {'id': entry.id, 'code': entry.code, 'name': entry.name, 'credit': entry.credit} if entry else None
+
+
+def _is_ug_student(student):
+    try:
+        return (student.batch_id.curriculum.programme.category or "").upper() == "UG"
+    except AttributeError:
+        return False
 
 
 def _student_programme_category(student):

--- a/FusionIIIT/applications/programme_curriculum/views_password_email.py
+++ b/FusionIIIT/applications/programme_curriculum/views_password_email.py
@@ -134,7 +134,7 @@ def send_password_email_smtp(student_email, student_name, password, roll_number,
                     <p>Your FUSION account has been created successfully. Please find your login credentials below:</p>
                     
                     <div style="background-color: #e3f2fd; padding: 20px; border-left: 4px solid #2196f3; margin: 20px 0; border-radius: 4px;">
-                        <p style="margin: 8px 0;"><strong>URL:</strong> <a href="http://fusion.iiitdmj.ac.in" style="color: #1976d2;">http://fusion.iiitdmj.ac.in</a></p>
+                        <p style="margin: 8px 0;"><strong>URL:</strong> <a href="https://fusion.iiitdmj.ac.in" style="color: #1976d2;">https://fusion.iiitdmj.ac.in</a></p>
                         <p style="margin: 8px 0;"><strong>Username:</strong> <code style="background-color: #f5f5f5; padding: 4px 8px; border-radius: 3px; font-family: monospace;">{roll_number}</code></p>
                         <p style="margin: 8px 0;"><strong>Password:</strong> <code style="background-color: #fff3cd; padding: 4px 8px; border-radius: 3px; font-family: monospace; color: #856404; border: 1px solid #ffeaa7;">{password}</code></p>
                     </div>

--- a/FusionIIIT/templates/registration/password_reset_complete.html
+++ b/FusionIIIT/templates/registration/password_reset_complete.html
@@ -8,6 +8,6 @@
 <body>
     <h2>Password Reset Successful</h2>
     <p>Your password has been reset successfully. You can now log in with your new password.</p>
-    <p><a href="http://fusion.iiitdmj.ac.in/accounts/login">Log In</a></p>
+    <p><a href="https://fusion.iiitdmj.ac.in/accounts/login">Log In</a></p>
 </body>
 </html>

--- a/FusionIIIT/templates/registration/password_reset_done.html
+++ b/FusionIIIT/templates/registration/password_reset_done.html
@@ -8,6 +8,6 @@
 <body>
     <h2>Check Your Email</h2>
     <p>If your email address is associated with an account, you will receive a password reset email shortly.</p>
-    <p><a href="http://fusion.iiitdmj.ac.in/">Back to Home</a></p>
+    <p><a href="https://fusion.iiitdmj.ac.in/">Back to Home</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Pre-registration stayed shut for the first semester

A registration window is looked up by an exact academic-calendar description. Pre-registration is keyed by the semester being registered **into**, so a student in semester 1 needs an event named `Pre Registration 2 <year>` — while add, drop, replace and PG registration all key on the semester the student is **in**. The office named the event after the current semester, which reads perfectly sensibly, and the page answered "Pre Registration date is not yet decided" with nothing to say which name it wanted.

**An event named `Pre Registration 0 <year>` now opens pre-registration for UG students in their first semester**, with that event's own from/to times governing. It is scoped to exactly that case:

| student | no `Pre Registration 0 <year>` | with it |
|---|---|---|
| UG, semester 1 | looks for `Pre Registration 2 <year>` | opens |
| non-UG, semester 1 | looks for `Pre Registration 2 <year>` | unchanged |
| any later semester | unchanged | unchanged |

**Every window now names the event it looked for.** Add, drop, replace, swayam, PG and PhD registration share the same helper, so a missing event reports the exact description the calendar lacks alongside the existing message, rather than leaving the convention to be guessed:

```
Pre Registration date is not yet decided
No academic calendar event named "Pre Registration 2 2026".
```

The calendar's description field is free text with no hint of the convention, so this is the difference between a five-minute fix and an afternoon of guessing.

## Portal links over http

The login-credentials mail and the two password-reset pages linked to the portal as `http://`. They now use `https://`; no `http://fusion` reference remains in the backend or its templates.

## Checks

Verified against real records with the calendar event created and rolled back: a first-semester UG student's window opens once the event exists, a non-UG student in the same semester is unaffected, and later semesters keep their existing key. `manage.py check` clean, no migrations.