### PR TITLE
Register a new intake into the semester it is already in, and require Devanagari for the Hindi name

### DIFF
--- a/FusionIIIT/applications/academic_procedures/api/views.py
+++ b/FusionIIIT/applications/academic_procedures/api/views.py
@@ -1169,12 +1169,12 @@ def verify_registration(request):
         batch = student.batch_id
         curr_id = batch.curriculum
         
-        if(student.curr_semester_no+1 >= 9):
-            # print('----------------------------------------------------------------' , student.curr_semester_no)
+        # Verify whichever semester the student actually registered for: a fresh
+        # intake registers into the semester it is already in, so assuming the
+        # next one would find nothing to verify and promote it a semester early.
+        sem_no = pre_registration_target_semester(student)
+        if sem_no >= 9:
             sem_no = 8
-        else:
-            # print('----------------------------------------------------------------' , student.curr_semester_no)
-            sem_no = student.curr_semester_no+1
         sem_id = Semester.objects.get(curriculum = curr_id, semester_no = sem_no)
         # print('----------------------------------------------------------------' , student.curr_semester_no)
         
@@ -1215,7 +1215,9 @@ def verify_registration(request):
             # course_registration.objects.bulk_create(ver_reg)
             academics_module_notif(request.user, student.id.user, 'registration_approved')
 
-            Student.objects.filter(id = student_id).update(curr_semester_no = sem_no)
+            # Only a registration for a later semester moves the student on.
+            if sem_no > student.curr_semester_no:
+                Student.objects.filter(id = student_id).update(curr_semester_no = sem_no)
             return JsonResponse({'status': 'success', 'message': 'Successfully Accepted'})
          
     elif data.get('status_req') == "reject" :
@@ -2921,16 +2923,24 @@ def get_drop_registration_eligibility(current_date, user_sem, year = datetime.da
 def get_replace_registration_eligibility(current_date, user_sem, year = datetime.datetime.now().year):
     return _check_registration_window(f"Replace {user_sem} {year}", "Replace course")
 
-def get_pre_registration_eligibility(current_date, user_sem, year = datetime.datetime.now().year,
-                                     student=None):
-    # Pre-registration is keyed by the semester being registered into, so a UG
-    # student in semester 1 needs "Pre Registration 2". The office opens that
-    # first cohort separately, so "Pre Registration 0" is accepted for them and
-    # takes precedence when it exists.
-    if student is not None and user_sem == 2 and _is_ug_student(student):
-        first_sem_event = f"Pre Registration 0 {year}"
-        if Calendar.objects.filter(description=first_sem_event).exists():
-            return _check_registration_window(first_sem_event, "Pre Registration")
+def pre_registration_target_semester(student):
+    """The semester a student's pre-registration belongs to.
+
+    Continuing students choose courses for the semester after the one they are
+    in. A newly admitted batch has nothing registered in its first semester yet,
+    so it registers into that semester rather than skipping past it.
+    """
+    current = student.curr_semester_no or 0
+    if current <= 1 and not course_registration.objects.filter(
+            student_id=student, semester_id__semester_no=current).exists():
+        return current
+    return current + 1
+
+
+def get_pre_registration_eligibility(current_date, user_sem, year = datetime.datetime.now().year):
+    # Keyed by the semester being registered into, so a newly admitted batch --
+    # which registers into the semester it is already in -- opens on
+    # "Pre Registration 1", and every later cohort on its own target semester.
     return _check_registration_window(f"Pre Registration {user_sem} {year}", "Pre Registration")
 
 def get_swayam_registration_eligibility(current_date, user_sem, year = datetime.datetime.now().year):
@@ -2982,7 +2992,7 @@ def get_preregistration_data(request):
         user_details = current_user.extrainfo
         student = Student.objects.get(id=user_details)
         semester_no = student.curr_semester_no
-        next_sem_no = semester_no+1
+        next_sem_no = pre_registration_target_semester(student)
         try:
             next_semester = Semester.objects.get(curriculum=student.batch_id.curriculum, semester_no=next_sem_no)
         except Semester.DoesNotExist:
@@ -3045,8 +3055,7 @@ def get_preregistration_data(request):
             return JsonResponse({"message": "Already registered", "data": data, "backlog_data":backlog_data}, safe=False)
         else:
             # If not already registered, return slots without pre-set priorities.
-            eligibility_resp = get_pre_registration_eligibility(
-                timezone.now().date(), next_sem_no, student=student)
+            eligibility_resp = get_pre_registration_eligibility(timezone.now().date(), next_sem_no)
             if isinstance(eligibility_resp, JsonResponse):
                 return eligibility_resp
             prev_registrations = serializers.CourseRegistrationSerializer(course_registration.objects.filter(student_id=student), many=True).data
@@ -3103,14 +3112,12 @@ def submit_preregistration(request):
         user_details = current_user.extrainfo
         student = Student.objects.get(id=user_details)
         semester_no = student.curr_semester_no
-        # Here you may want to use next_sem_no = semester_no + 1 if that is the logic.
-        next_sem_no = semester_no+1
+        next_sem_no = pre_registration_target_semester(student)
         try:
             next_semester = Semester.objects.get(curriculum=student.batch_id.curriculum, semester_no=next_sem_no)
         except Semester.DoesNotExist:
             return JsonResponse({"error": "Not Eligible for Pre Registration"}, status=400)
-        eligibility_resp = get_pre_registration_eligibility(
-            timezone.now().date(), next_sem_no, student=student)
+        eligibility_resp = get_pre_registration_eligibility(timezone.now().date(), next_sem_no)
         if isinstance(eligibility_resp, JsonResponse):
             return eligibility_resp
     except Student.DoesNotExist:
@@ -8804,13 +8811,6 @@ def _resolve_discipline_matched_entry(manager, student):
 
 def _catalog_entry_to_dict(entry):
     return {'id': entry.id, 'code': entry.code, 'name': entry.name, 'credit': entry.credit} if entry else None
-
-
-def _is_ug_student(student):
-    try:
-        return (student.batch_id.curriculum.programme.category or "").upper() == "UG"
-    except AttributeError:
-        return False
 
 
 def _student_programme_category(student):

--- a/FusionIIIT/applications/programme_curriculum/api/views_student_profile.py
+++ b/FusionIIIT/applications/programme_curriculum/api/views_student_profile.py
@@ -132,6 +132,15 @@ def student_profile_completion_submit(request):
     if apaar and not re.fullmatch(r"\d{12}", apaar):
         errors["apaar_id"] = "APAAR ID must be exactly 12 digits"
 
+    # The Hindi name has to be in Devanagari: the Latin spelling is already the
+    # name field, so a repeat of it here carries nothing.
+    hindi_name = text("hindi_name")
+    if hindi_name and not (
+        re.search(r"[\u0900-\u097F]", hindi_name)
+        and re.fullmatch(r"[\u0900-\u097F\u200c\u200d\s.'-]+", hindi_name)
+    ):
+        errors["hindi_name"] = "Name (Hindi) must be written in Devanagari, not English"
+
     phone = str(text("phone_number"))
     father_mobile = str(text("father_mobile"))
     mother_mobile = str(text("mother_mobile"))
@@ -164,7 +173,7 @@ def student_profile_completion_submit(request):
 
     rec.aadhar_number = aadhar
     rec.apaar_id = apaar
-    rec.hindi_name = text("hindi_name")
+    rec.hindi_name = hindi_name
     rec.phone_number = phone
     rec.blood_group = blood_group
     rec.blood_group_remarks = blood_remarks

--- a/FusionIIIT/applications/programme_curriculum/test_student_profile.py
+++ b/FusionIIIT/applications/programme_curriculum/test_student_profile.py
@@ -141,6 +141,24 @@ class StudentProfileCompletionTests(TestCase):
         self.assertEqual(resp.status_code, 400)
         self.assertIn("apaar_id", resp.json()["errors"])
 
+    def test_hindi_name_must_be_devanagari(self):
+        resp = self._submit(_valid_payload(hindi_name="Chhatra Kumar"))
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("hindi_name", resp.json()["errors"])
+        self.student.refresh_from_db()
+        self.assertFalse(self.student.profile_completed)
+
+    def test_hindi_name_rejects_a_mixed_spelling(self):
+        resp = self._submit(_valid_payload(hindi_name="छात्र Kumar"))
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("hindi_name", resp.json()["errors"])
+
+    def test_hindi_name_accepts_devanagari_with_spaces(self):
+        resp = self._submit(_valid_payload(hindi_name="छात्र कुमार"))
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.student.refresh_from_db()
+        self.assertEqual(self.student.hindi_name, "छात्र कुमार")
+
     def test_at_least_one_parent_mobile(self):
         resp = self._submit(_valid_payload(father_mobile="", mother_mobile=""))
         self.assertEqual(resp.status_code, 400)


### PR DESCRIPTION
## A new intake could not pre-register for its own first semester

Pre-registration stores rows against the semester being registered **into**, which for a continuing student is the one after the semester they are in. Applied to a batch that has just arrived, that rule skipped the first semester: those students were offered the *second* semester's courses, and no calendar name could open the first semester at all.

The target semester is now decided by whether the student has anything registered in the semester they are in:

| student | registers into |
|---|---|
| just admitted — first semester, nothing registered | that same semester |
| first semester, courses already registered | the next one |
| any later semester | the next one |

The rule corrects itself: once the intake's first-semester registration exists, that student's next pre-registration targets the following semester, with no flag to unset.

Checked against a copy of production: a first-semester student with no courses is offered 6 slots, all from semester 1 of their own curriculum, where previously they were offered semester 2. Students with 18 and 32 registrations behind them are unaffected, as is a first-semester student who already has courses.

**Verification follows the same rule** rather than assuming the next semester — otherwise it would look for a registration that does not exist — and it promotes a student **only when the semester registered is ahead** of the one they are in. Without that, verifying an intake's first-semester registration would move them into the second semester on the day they arrived.

**The calendar convention now has no exceptions.** The number in `Pre Registration <n> <year>` is always the semester being registered into, so the intake opens on `Pre Registration 1 <year>` and every later cohort on its own target. An earlier `Pre Registration 0` spelling has been removed.

Course lists are unchanged and remain per branch: slots come from `student → batch → curriculum → semester`, so each discipline sees only its own first-semester courses.

## The Hindi name must be in Devanagari

The first-login profile popup collects a Hindi name beside the Latin one, and accepted anything — an English repeat of the name carried no information. It now requires at least one Devanagari character and permits only Devanagari, spaces and the punctuation names use, including the zero-width joiners conjuncts need. Latin letters, digits and mixed spellings are rejected, on the server and in the form.

Three tests added: English rejected, mixed spelling rejected, Devanagari with spaces accepted and stored.

## Deploying

Two follow-ups on the production database, neither of which this migration can do:

- rename the calendar event to `Pre Registration 1 <year>` for the intake;
- clear any pre-registration rows a first-semester student created under the second semester while the old rule applied, together with their `StudentRegistrationChecks` row — the page returns an existing registration before it consults the calendar, so stale rows keep being shown.

`manage.py check` clean, no migrations.