### PR TITLE
Refuse a pre-registration that selects nothing

### DIFF
--- a/FusionIIIT/applications/academic_procedures/api/views.py
+++ b/FusionIIIT/applications/academic_procedures/api/views.py
@@ -3107,6 +3107,15 @@ def submit_preregistration(request):
 
     registrations = data.get("registrations", [])
     backlog_registrations = data.get("backlog_registrations", [])
+
+    # Marking pre-registration complete for an empty submission saved nothing and
+    # then locked the student out, since the page returns an existing
+    # registration before it offers the form again.
+    if not registrations and not backlog_registrations:
+        return JsonResponse(
+            {"error": "Select at least one course before submitting your pre-registration."},
+            status=400)
+
     try:
         current_user = request.user
         user_details = current_user.extrainfo


### PR DESCRIPTION
## What happens today

`submit_preregistration` marks the student complete regardless of what was submitted:

```python
reg_check, created = StudentRegistrationChecks.objects.get_or_create(
    student_id=student, semester_id_id=next_semester.id,
    defaults={'pre_registration_flag': True})
```

Nothing checks that `registrations` or `backlog_registrations` contained anything. A student who submits the form without choosing courses therefore ends up with **zero saved choices and the flag set** — and because the page returns an existing registration *before* it offers the form again, they are locked out of a registration they never made. The only way back is a database edit; it has already caught students in the current intake.

## Change

An empty submission is refused:

```
400  Select at least one course before submitting your pre-registration.
```

No rows, no flag, so the student simply picks their courses and submits.

Verified against a first-semester student, rolled back afterwards:

| submission | response | rows / flags after |
|---|---|---|
| no courses | `400` with the message above | `(0, 0)` — nothing written |
| one course | `201 {"status": "success"}` | `(1, 1)` |

## Note for whoever is running the current window

This prevents new cases; it does not release students already stuck. Those have a `StudentRegistrationChecks` row with the flag set and no matching `InitialRegistration` rows, and deleting that row lets them register again. Scope any such cleanup to the current batch — the same pattern matches thousands of older rows whose choices were legitimately consumed by allotment.

`manage.py check` clean, no migrations.