### PR TITLE
Accept alphanumeric sections in the course-instructor form

### DIFF
--- a/FusionIIIT/applications/academic_information/models.py
+++ b/FusionIIIT/applications/academic_information/models.py
@@ -72,17 +72,6 @@ class Constants:
         ('Management Science', 'Management Science'),
     )
 
-    # B.Tech section labels. CSE is split into A/B by roll-number parity; every
-    # other discipline maps to a single section. See compute_section() below.
-    SECTION_CHOICES = (
-        ('A', 'A'),
-        ('B', 'B'),
-        ('C', 'C'),
-        ('D', 'D'),
-        ('E', 'E'),
-        ('F', 'F'),
-    )
-
 
 def compute_section(discipline_name, roll_no, programme=None):
     """Return the section (A-F) for an undergraduate student, else None.

--- a/FusionIIIT/applications/programme_curriculum/api/views.py
+++ b/FusionIIIT/applications/programme_curriculum/api/views.py
@@ -3637,8 +3637,8 @@ def add_course_instructor(request):
                     sec = None
                     if sheet.ncols > 5:
                         sec = str(sheet.cell(i, 5).value).strip().upper() or None
-                    if sec is not None and sec not in ('A', 'B', 'C', 'D', 'E', 'F'):
-                        raise ValueError(f"Bad section '{sec}' (expected A-F or blank)")
+                    if sec is not None and not (len(sec) <= 8 and sec.isalnum()):
+                        raise ValueError(f"Bad section '{sec}' (up to 8 letters or digits, or blank)")
 
                     # convert year
                     year = parse_academic_year(acad_year, sem_type)

--- a/FusionIIIT/applications/programme_curriculum/forms.py
+++ b/FusionIIIT/applications/programme_curriculum/forms.py
@@ -417,18 +417,21 @@ class CourseInstructorForm(forms.ModelForm):
         label="Select Semester Type",
         widget=forms.Select(attrs={'class': 'ui fluid search selection dropdown'})
     )
-    section_label = forms.ChoiceField(
-        choices=[('', 'No section (single-offering / elective)')] + [(s, s) for s in ['A', 'B', 'C', 'D', 'E', 'F']],
+    section_label = forms.CharField(
         required=False,
+        max_length=8,
         label="Section",
-        widget=forms.Select(attrs={'class': 'ui fluid search selection dropdown'})
+        widget=forms.TextInput(attrs={'class': 'ui fluid input',
+                                      'placeholder': 'No section (single-offering / elective)'})
     )
 
     def clean_section_label(self):
         # Normalise blank -> None so a single-offering elective stays NULL
-        # (one elective offering per course/term is enforced in the view); a
-        # letter A-F identifies a core section owned by exactly one faculty.
+        # (one elective offering per course/term is enforced in the view). The
+        # office invents its own labels, so any short alphanumeric one is taken.
         value = (self.cleaned_data.get('section_label') or '').strip().upper()
+        if value and not value.isalnum():
+            raise forms.ValidationError('Section can be up to 8 letters or digits.')
         return value or None
 
     class Meta:


### PR DESCRIPTION
Adding or editing a course instructor rejected any section outside A-F — `{"section_label": ["Select a valid choice. E1 is not one of the available choices."]}` — even though the section dropdown offers whatever sections exist. The model and the assign-section endpoint were relaxed earlier; the form field kept a hardcoded six-letter choice list, and the Excel upload branch kept the same list in its own check.

- `CourseInstructorForm.section_label` is now a text field validated to up to eight letters or digits, the same rule the assign-section endpoint uses. Blank still means a single-offering elective.
- The Excel upload branch uses that rule instead of `expected A-F or blank`.
- Dropped the `SECTION_CHOICES` tuple left on the student model; nothing referenced it once the field lost its choices.

Add and edit share the form, so both paths are covered.

Checked against a copy of the live database, rolled back afterwards: `E1`, `CS2`, `G` and blank are accepted; a label with punctuation and one over eight characters are rejected with a readable message. `manage.py check` clean, no new migrations.