### PR TITLE
Publish and resume course allocations

### DIFF
--- a/FusionIIIT/applications/academic_information/api/views.py
+++ b/FusionIIIT/applications/academic_information/api/views.py
@@ -11,7 +11,9 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 import xlsxwriter
 from applications.academic_procedures.models import course_registration
-from applications.academic_information.utils import allocate, check_for_registration_complete
+from applications.academic_information.utils import (
+    allocate, check_for_registration_complete, publish_allocations,
+)
 from applications.globals.models import (HoldsDesignation,Designation)
 from django.shortcuts import get_object_or_404
 from django.forms.models import model_to_dict
@@ -281,6 +283,15 @@ def check_allocation_api(request):
             )
 
         result = check_for_registration_complete(batch, sem, year, programme_type)
+
+        # Older allocations stopped at FinalRegistration.  Checking one now
+        # also publishes any missing course_registration rows, so all academic
+        # consumers immediately see the same allocation without a separate
+        # Verify Registration step.
+        if result.get("status") == 2:
+            result["publication"] = publish_allocations(
+                batch, sem, year, programme_type)
+            result["message"] = "Courses already allocated and published"
 
         # Map status values to appropriate HTTP codes
         status_code_map = {

--- a/FusionIIIT/applications/academic_information/tests.py
+++ b/FusionIIIT/applications/academic_information/tests.py
@@ -1,3 +1,198 @@
-# from django.test import TestCase
+import json
+from types import SimpleNamespace
 
-# Create your tests here.
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from applications.academic_information.models import Student
+from applications.academic_information.utils import (
+    allocate, allocation_progress, publish_allocations,
+)
+from applications.academic_procedures.models import (
+    FinalRegistration, InitialRegistration, course_registration,
+)
+from applications.globals.models import ExtraInfo, Faculty
+from applications.programme_curriculum.models import (
+    Batch, Course, CourseInstructor, CourseSlot, Curriculum, Discipline,
+    Programme, Semester,
+)
+
+
+class AllocationPublicationTests(TestCase):
+    def setUp(self):
+        programme = Programme.objects.create(
+            category='UG', name='Test B.Tech', programme_begin_year=2026)
+        discipline = Discipline.objects.create(
+            name='Test Computer Science', acronym='TCSE')
+        curriculum = Curriculum.objects.create(
+            programme=programme, name='Test B.Tech Curriculum',
+            no_of_semester=8)
+        self.semester = Semester.objects.create(
+            curriculum=curriculum, semester_no=1)
+        self.batch = Batch.objects.create(
+            name='B.Tech', discipline=discipline, year=2026,
+            curriculum=curriculum)
+        self.course = Course.objects.create(
+            code='TT1001', name='Test Course', credit=4, syllabus='',
+            ref_books='', max_seats=60)
+        self.slot = CourseSlot.objects.create(
+            semester=self.semester, name='Test Core Slot',
+            type='Professional Core')
+        self.slot.courses.add(self.course)
+
+        student_user = User.objects.create_user(username='26TCS001')
+        student_extra = ExtraInfo.objects.create(
+            id='26TCS001', user=student_user, user_type='student')
+        self.student = Student.objects.create(
+            id=student_extra, programme='B.Tech', batch=2026,
+            batch_id=self.batch, category='GEN', curr_semester_no=1,
+            section='E1')
+
+        faculty_user = User.objects.create_user(
+            username='TFAC001', first_name='Test', last_name='Faculty')
+        faculty_extra = ExtraInfo.objects.create(
+            id='TFAC001', user=faculty_user, user_type='faculty')
+        faculty = Faculty.objects.create(id=faculty_extra)
+        self.offering = CourseInstructor.objects.create(
+            course_id=self.course, instructor_id=faculty, year=2026,
+            semester_type='Odd Semester', section_label='E1')
+
+        InitialRegistration.objects.create(
+            student_id=self.student, semester_id=self.semester,
+            course_id=self.course, course_slot_id=self.slot, priority=1,
+            registration_type='Regular')
+
+    def create_second_student(self):
+        user = User.objects.create_user(username='26TCS002')
+        extra = ExtraInfo.objects.create(
+            id='26TCS002', user=user, user_type='student')
+        student = Student.objects.create(
+            id=extra, programme='B.Tech', batch=2026,
+            batch_id=self.batch, category='GEN', curr_semester_no=1,
+            section='E1')
+        InitialRegistration.objects.create(
+            student_id=student, semester_id=self.semester,
+            course_id=self.course, course_slot_id=self.slot, priority=1,
+            registration_type='Regular')
+        return student
+
+    def test_allocate_immediately_publishes_courses(self):
+        response = allocate(SimpleNamespace(POST={
+            'batch': 2026,
+            'sem': 1,
+            'year': 2026,
+            'programme_type': 'UG',
+            'skip_course_ids': [],
+        }))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content)['status'], 1)
+
+        allocation = FinalRegistration.objects.get()
+        self.assertTrue(allocation.verified)
+        self.assertEqual(allocation.course_instructor, self.offering)
+
+        registration = course_registration.objects.get()
+        self.assertEqual(registration.student_id, self.student)
+        self.assertEqual(registration.course_id, self.course)
+        self.assertEqual(registration.semester_id, self.semester)
+        self.assertEqual(registration.course_instructor, self.offering)
+        self.assertEqual(registration.working_year, 2026)
+        self.assertEqual(registration.session, '2026-27')
+        self.assertEqual(registration.semester_type, 'Odd Semester')
+
+    def test_publish_repairs_old_allocations_without_duplicates(self):
+        FinalRegistration.objects.create(
+            student_id=self.student, semester_id=self.semester,
+            course_id=self.course, course_slot_id=self.slot,
+            registration_type='Regular', verified=True)
+
+        first = publish_allocations(2026, 1, 2026, 'UG')
+        second = publish_allocations(2026, 1, 2026, 'UG')
+
+        self.assertEqual(first['registrations_created'], 1)
+        self.assertEqual(second['registrations_created'], 0)
+        self.assertEqual(second['registrations_updated'], 1)
+        self.assertEqual(course_registration.objects.count(), 1)
+        self.assertEqual(
+            course_registration.objects.get().course_instructor,
+            self.offering,
+        )
+
+    def test_allocate_preserves_existing_and_allocates_only_remaining_students(self):
+        second_student = self.create_second_student()
+        existing = FinalRegistration.objects.create(
+            student_id=self.student, semester_id=self.semester,
+            course_id=self.course, course_slot_id=self.slot,
+            registration_type='Regular', verified=True,
+            course_instructor=self.offering)
+        publish_allocations(2026, 1, 2026, 'UG')
+
+        before = allocation_progress(2026, 1, 'UG')
+        self.assertEqual(before['allocated_allocations'], 1)
+        self.assertEqual(before['remaining_students'], 1)
+
+        response = allocate(SimpleNamespace(POST={
+            'batch': 2026,
+            'sem': 1,
+            'year': 2026,
+            'programme_type': 'UG',
+            'skip_course_ids': [],
+        }))
+
+        self.assertEqual(json.loads(response.content)['status'], 1)
+        self.assertTrue(FinalRegistration.objects.filter(pk=existing.pk).exists())
+        self.assertEqual(FinalRegistration.objects.count(), 2)
+        self.assertTrue(FinalRegistration.objects.filter(
+            student_id=second_student, verified=True).exists())
+        self.assertEqual(course_registration.objects.count(), 2)
+        after = allocation_progress(2026, 1, 'UG')
+        self.assertEqual(after['remaining_allocations'], 0)
+
+    def test_partial_allocation_response_reports_remaining_students(self):
+        self.create_second_student()
+        existing = FinalRegistration.objects.create(
+            student_id=self.student, semester_id=self.semester,
+            course_id=self.course, course_slot_id=self.slot,
+            registration_type='Regular', verified=True,
+            course_instructor=self.offering)
+
+        response = allocate(SimpleNamespace(POST={
+            'batch': 2026,
+            'sem': 1,
+            'year': 2026,
+            'programme_type': 'UG',
+            'skip_course_ids': [self.course.id],
+        }))
+        payload = json.loads(response.content)
+
+        self.assertEqual(payload['status'], 1)
+        self.assertEqual(payload['progress']['remaining_students'], 1)
+        self.assertTrue(FinalRegistration.objects.filter(pk=existing.pk).exists())
+        self.assertEqual(FinalRegistration.objects.count(), 1)
+
+    def test_open_elective_resume_skips_already_allocated_student(self):
+        self.slot.type = 'Open Elective'
+        self.slot.save(update_fields=['type'])
+        second_student = self.create_second_student()
+        existing = FinalRegistration.objects.create(
+            student_id=self.student, semester_id=self.semester,
+            course_id=self.course, course_slot_id=self.slot,
+            registration_type='Regular', verified=True,
+            course_instructor=self.offering)
+
+        response = allocate(SimpleNamespace(POST={
+            'batch': 2026,
+            'sem': 1,
+            'year': 2026,
+            'programme_type': 'UG',
+            'skip_course_ids': [],
+        }))
+        payload = json.loads(response.content)
+
+        self.assertEqual(payload['status'], 1)
+        self.assertEqual(payload['progress']['remaining_allocations'], 0)
+        self.assertTrue(FinalRegistration.objects.filter(pk=existing.pk).exists())
+        self.assertTrue(FinalRegistration.objects.filter(
+            student_id=second_student).exists())
+        self.assertEqual(FinalRegistration.objects.count(), 2)

--- a/FusionIIIT/applications/academic_information/utils.py
+++ b/FusionIIIT/applications/academic_information/utils.py
@@ -1,10 +1,12 @@
 from applications.academic_information.models import (Calendar, Student,Curriculum_Instructor, Curriculum,
-                                                      Student_attendance)
+                                                      Student_attendance, offerings_by_course,
+                                                      pick_offering)
 from ..academic_procedures.models import (BranchChange, CoursesMtech, FinalRegistrations, InitialRegistration, StudentRegistrationChecks,
                      Register, Thesis, FinalRegistration, ThesisTopicProcess,
                      Constants, FeePayments, TeachingCreditRegistration, SemesterMarks,
                      MarkSubmissionCheck, Dues,AssistantshipClaim, MTechGraduateSeminarReport,
-                     PhDProgressExamination,CourseRequested, course_registration, MessDue, Assistantship_status , backlog_course,)
+                     PhDProgressExamination,CourseRequested, course_registration, course_replacement,
+                     MessDue, Assistantship_status , backlog_course,)
 
 from applications.programme_curriculum.models import(Course,CourseSlot,Batch,Semester)
 from django.http import HttpResponse, JsonResponse
@@ -27,15 +29,31 @@ def validate_course_slots(batch, sem, programme_type, skip_course_ids=None):
     """
     skip_course_ids = {int(c) for c in (skip_course_ids or [])}
 
-    pairs = (InitialRegistration.objects
-             .filter(Q(semester_id__semester_no=sem)
-                     & Q(student_id__batch=batch)
-                     & Q(student_id__batch_id__curriculum__programme__category=programme_type))
-             .exclude(course_id__isnull=True)
-             .exclude(course_slot_id__isnull=True)
-             .values('course_id', 'course_slot_id')
-             .annotate(students=Count('id')))
-    pairs = [p for p in pairs if p['course_id'] not in skip_course_ids]
+    scope = (
+        Q(semester_id__semester_no=sem)
+        & Q(student_id__batch=batch)
+        & Q(student_id__batch_id__curriculum__programme__category=programme_type)
+    )
+    already_allocated = set(
+        FinalRegistration.objects.filter(scope)
+        .exclude(course_slot_id__isnull=True)
+        .values_list('student_id_id', 'course_slot_id_id')
+    )
+    pair_counts = {}
+    requested = (InitialRegistration.objects.filter(scope)
+                 .exclude(course_id__isnull=True)
+                 .exclude(course_slot_id__isnull=True)
+                 .values('student_id', 'course_id', 'course_slot_id'))
+    for row in requested:
+        if ((row['student_id'], row['course_slot_id']) in already_allocated
+                or row['course_id'] in skip_course_ids):
+            continue
+        key = (row['course_id'], row['course_slot_id'])
+        pair_counts[key] = pair_counts.get(key, 0) + 1
+    pairs = [
+        {'course_id': course_id, 'course_slot_id': slot_id, 'students': count}
+        for (course_id, slot_id), count in pair_counts.items()
+    ]
     if not pairs:
         return []
 
@@ -76,6 +94,37 @@ def validate_course_slots(batch, sem, programme_type, skip_course_ids=None):
         entry['students'] += p['students']
 
     return sorted(problems.values(), key=lambda e: -e['students'])
+
+
+def allocation_progress(batch, sem, programme_type):
+    """Return coverage of requested student/slot pairs by final allotments."""
+    scope = (
+        Q(semester_id__semester_no=sem)
+        & Q(student_id__batch=batch)
+        & Q(student_id__batch_id__curriculum__programme__category=programme_type)
+    )
+    requested = set(
+        InitialRegistration.objects.filter(scope)
+        .exclude(course_id__isnull=True)
+        .exclude(course_slot_id__isnull=True)
+        .values_list('student_id_id', 'course_slot_id_id')
+        .distinct()
+    )
+    allotted = set(
+        FinalRegistration.objects.filter(scope)
+        .exclude(course_slot_id__isnull=True)
+        .values_list('student_id_id', 'course_slot_id_id')
+        .distinct()
+    ) & requested
+    remaining = requested - allotted
+    return {
+        'total_allocations': len(requested),
+        'allocated_allocations': len(allotted),
+        'remaining_allocations': len(remaining),
+        'remaining_students': len({student_id for student_id, _ in remaining}),
+    }
+
+
 def check_for_registration_complete(batch, sem, year, programme_type):
     date = datetime.date.today()
     try:
@@ -92,13 +141,175 @@ def check_for_registration_complete(batch, sem, year, programme_type):
         if prd_start_date <= date <= prd_end_date:
             return {"status": -1, "message": "Registration is under process"}
 
-        if FinalRegistration.objects.filter(Q(semester_id__semester_no = sem) & Q(student_id__batch = batch) & Q(student_id__batch_id__curriculum__programme__category=programme_type)).exists() :
-            return {"status": 2, "message": "Courses already allocated"}
+        progress = allocation_progress(batch, sem, programme_type)
+        if (progress['total_allocations'] > 0
+                and progress['remaining_allocations'] == 0):
+            return {
+                "status": 2,
+                "message": "All requested courses are allocated",
+                **progress,
+            }
 
-        return {"status": 1, "message": "Courses not yet allocated"}
+        if progress['allocated_allocations']:
+            return {
+                "status": 1,
+                "message": (
+                    f"Allocation is incomplete: {progress['remaining_students']} "
+                    "student(s) still need one or more courses."
+                ),
+                **progress,
+            }
+
+        return {
+            "status": 1,
+            "message": "Courses not yet allocated",
+            **progress,
+        }
     
     except Exception as e:
         return {"status": -3, "message": f"Internal Server Error: {str(e)}"}
+
+
+def _allocation_term(year, sem):
+    """Return the canonical course-registration values for an allocation term."""
+    working_year = int(year)
+    semester_type = "Even Semester" if int(sem) % 2 == 0 else "Odd Semester"
+    if semester_type == "Even Semester":
+        session = f"{working_year - 1}-{str(working_year)[-2:]}"
+    else:
+        session = f"{working_year}-{str(working_year + 1)[-2:]}"
+    return working_year, semester_type, session
+
+
+@transaction.atomic
+def publish_allocations(batch, sem, year, programme_type):
+    """Publish allotted courses to the canonical registration table.
+
+    ``FinalRegistration`` is the allocation workspace, while almost every
+    downstream academic screen reads ``course_registration``.  Allocation is
+    the final step in the current workflow, so materialise the latter here and
+    mark the workspace rows verified.  The operation includes already-verified
+    rows and is idempotent, allowing Check Allocation to repair older batches
+    that were allotted before automatic publication existed.
+    """
+    batch = int(batch)
+    sem = int(sem)
+    working_year, semester_type, session = _allocation_term(year, sem)
+
+    allocation_filter = (
+        Q(semester_id__semester_no=sem)
+        & Q(student_id__batch=batch)
+        & Q(student_id__batch_id__curriculum__programme__category=programme_type)
+    )
+    allocations = list(
+        FinalRegistration.objects.filter(allocation_filter).select_related(
+            'student_id', 'semester_id', 'course_id', 'course_slot_id',
+            'old_course_registration',
+        )
+    )
+    if not allocations:
+        return {
+            'allocations_published': 0,
+            'registrations_created': 0,
+            'registrations_updated': 0,
+        }
+
+    offerings = offerings_by_course(
+        {row.course_id_id for row in allocations}, working_year, semester_type)
+
+    existing_rows = list(course_registration.objects.filter(
+        student_id__batch=batch,
+        semester_id__semester_no=sem,
+        student_id__batch_id__curriculum__programme__category=programme_type,
+    ))
+    existing_by_key = {
+        (row.student_id_id, row.course_id_id, row.semester_id_id,
+         row.registration_type): row
+        for row in existing_rows
+    }
+
+    to_create = []
+    to_update = []
+    for allocation in allocations:
+        offering = pick_offering(
+            allocation.student_id,
+            offerings.get(allocation.course_id_id, []),
+        )
+        key = (
+            allocation.student_id_id,
+            allocation.course_id_id,
+            allocation.semester_id_id,
+            allocation.registration_type,
+        )
+        registration = existing_by_key.get(key)
+        if registration is None:
+            to_create.append(course_registration(
+                student_id_id=allocation.student_id_id,
+                semester_id_id=allocation.semester_id_id,
+                course_id_id=allocation.course_id_id,
+                course_slot_id=allocation.course_slot_id,
+                registration_type=allocation.registration_type,
+                working_year=working_year,
+                session=session,
+                semester_type=semester_type,
+                course_instructor=offering,
+            ))
+        else:
+            registration.course_slot_id = allocation.course_slot_id
+            registration.working_year = working_year
+            registration.session = session
+            registration.semester_type = semester_type
+            registration.course_instructor = offering
+            to_update.append(registration)
+
+        allocation.course_instructor = offering
+        allocation.verified = True
+
+    if to_create:
+        # The model's unique constraint makes this safe if two administrators
+        # check the same allocation concurrently.
+        course_registration.objects.bulk_create(to_create, ignore_conflicts=True)
+    if to_update:
+        course_registration.objects.bulk_update(
+            to_update,
+            ['course_slot_id', 'working_year', 'session', 'semester_type',
+             'course_instructor'],
+        )
+
+    FinalRegistration.objects.bulk_update(
+        allocations, ['verified', 'course_instructor'])
+
+    # Re-query so IDs are available on every supported database after
+    # bulk_create, then preserve backlog/improvement replacement links.
+    published_by_key = {
+        (row.student_id_id, row.course_id_id, row.semester_id_id,
+         row.registration_type): row
+        for row in course_registration.objects.filter(
+            student_id__batch=batch,
+            semester_id__semester_no=sem,
+            student_id__batch_id__curriculum__programme__category=programme_type,
+        )
+    }
+    for allocation in allocations:
+        if allocation.old_course_registration_id:
+            key = (
+                allocation.student_id_id,
+                allocation.course_id_id,
+                allocation.semester_id_id,
+                allocation.registration_type,
+            )
+            published = published_by_key.get(key)
+            if published is not None:
+                course_replacement.objects.get_or_create(
+                    old_course_registration_id=allocation.old_course_registration_id,
+                    new_course_registration=published,
+                )
+
+    return {
+        'allocations_published': len(allocations),
+        'registrations_created': len(to_create),
+        'registrations_updated': len(to_update),
+    }
 
 @transaction.atomic
 def random_algo(batch,sem,year,course_slot, programme_type, skip_course_ids=None) :
@@ -107,6 +318,14 @@ def random_algo(batch,sem,year,course_slot, programme_type, skip_course_ids=None
     skip_course_ids = {int(c) for c in (skip_course_ids or [])}
     unique_course = InitialRegistration.objects.filter(Q(semester_id__semester_no = sem) & Q( course_slot_id__name = course_slot ) & Q(student_id__batch = batch) & Q(student_id__batch_id__curriculum__programme__category=programme_type)).values_list('course_id',flat=True).distinct()
     slot_filter = (Q(semester_id__semester_no = sem) & Q( course_slot_id__name = course_slot ) & Q(student_id__batch = batch) & Q(student_id__batch_id__curriculum__programme__category=programme_type))
+    already_allocated_students = set(FinalRegistration.objects.filter(
+        Q(semester_id__semester_no=sem)
+        & Q(course_slot_id__name=course_slot)
+        & Q(student_id__batch=batch)
+        & Q(student_id__batch_id__curriculum__programme__category=programme_type)
+    ).values_list('student_id_id', flat=True))
+    pending_registrations = InitialRegistration.objects.filter(slot_filter).exclude(
+        student_id_id__in=already_allocated_students)
     max_seats={}
     seats_alloted = {}
     present_priority = {}
@@ -127,12 +346,12 @@ def random_algo(batch,sem,year,course_slot, programme_type, skip_course_ids=None
             max_seats[course] = 0
         else :
             max_seats[course] = course_caps.get(course, 0)
-            total_seats+=max_seats[course]
         seats_alloted[course] = already_alloted.get(course, 0)
+        total_seats += max(0, max_seats[course] - seats_alloted[course])
         present_priority[course] = []
         next_priority[course] = []
 
-    priority_1 = InitialRegistration.objects.filter(slot_filter & Q(priority=1))
+    priority_1 = pending_registrations.filter(priority=1)
     rem=len(priority_1)
     if rem > total_seats :
         return -1
@@ -142,7 +361,7 @@ def random_algo(batch,sem,year,course_slot, programme_type, skip_course_ids=None
 
     # the fall-through lookup was one query per bumped student
     choice_by_priority = {}
-    for stud_id, prio, c_id, cs_id in InitialRegistration.objects.filter(slot_filter).values_list(
+    for stud_id, prio, c_id, cs_id in pending_registrations.values_list(
             'student_id_id', 'priority', 'course_id_id', 'course_slot_id_id') :
         choice_by_priority.setdefault((stud_id, prio), (c_id, cs_id))
 
@@ -218,12 +437,19 @@ def allocate(request):
                 course_slot_object = CourseSlot.objects.get(id=entry['course_slot_id'])
 
                 if course_slot_object.type != "Open Elective":
+                    already_allocated_students = FinalRegistration.objects.filter(
+                        semester_id__semester_no=sem,
+                        course_slot_id=course_slot_object,
+                        student_id__batch=batch,
+                        student_id__batch_id__curriculum__programme__category=programme_type,
+                    ).values_list('student_id_id', flat=True)
                     # one row per student for this slot, instead of five queries each
                     registrations = list(InitialRegistration.objects.filter(
                         Q(semester_id__semester_no=sem) &
                         Q(course_slot_id=course_slot_object) &
                         Q(student_id__batch=batch) & Q(student_id__batch_id__curriculum__programme__category=programme_type)
-                    ).values_list('student_id_id', 'course_id_id', 'registration_type',
+                    ).exclude(student_id_id__in=already_allocated_students)
+                    .values_list('student_id_id', 'course_id_id', 'registration_type',
                                   'old_course_registration_id'))
 
                     curriculum_by_student = dict(Student.objects.filter(
@@ -249,7 +475,8 @@ def allocate(request):
                             registration_type=regis,
                             old_course_registration_id=prev_registration_id
                         ))
-                    FinalRegistration.objects.bulk_create(slot_rows)
+                    FinalRegistration.objects.bulk_create(
+                        slot_rows, ignore_conflicts=True)
 
                     unique_course_name.append(course_slot_object.name)
 
@@ -261,12 +488,25 @@ def allocate(request):
                         if stat == -1:
                             raise Exception(f"Seats not enough for course_slot {course_slot_object.name}")
 
-        message = "Course allocation successful"
+            publication = publish_allocations(
+                batch, sem, year, programme_type)
+            progress = allocation_progress(batch, sem, programme_type)
+
+        if progress['remaining_allocations']:
+            message = (
+                "Allocation partially published; "
+                f"{progress['remaining_students']} student(s) still need "
+                "one or more courses"
+            )
+        else:
+            message = "Course allocation published successfully"
         if skip_course_ids:
             message += (f" ({len(skip_course_ids)} course(s) skipped"
                         f"; {skipped_students} student(s) left without a course in a single-choice slot)")
         return JsonResponse({'status': 1, 'message': message,
-                             'skipped_course_ids': sorted(skip_course_ids)})
+                             'skipped_course_ids': sorted(skip_course_ids),
+                             'publication': publication,
+                             'progress': progress})
 
     except Exception as e:
         return JsonResponse({'status': -1, 'message': str(e) or "Allocation failed"})


### PR DESCRIPTION
## Summary
- publish allotted courses to canonical course registrations immediately
- resume partial allocations without changing completed student-slot assignments
- repair previously allotted batches during allocation checks
- preserve section, instructor, term, and replacement metadata

## Validation
- 5 focused allocation tests passed
- Python compilation and diff checks passed