### PR TITLE
Normalize PhD student list filtering

### DIFF
--- a/FusionIIIT/applications/academic_information/api/views.py
+++ b/FusionIIIT/applications/academic_information/api/views.py
@@ -34,11 +34,34 @@ from django.http import HttpResponse, JsonResponse
 from django.db.models import Q
 from applications.globals.decorators import role_required
 from applications.globals.api.views import resolve_audience_recipients
+from applications.globals.programme_scope import PROGRAMME_NAMES_BY_SCOPE
 from notifications.signals import notify
 from django.core.cache import cache
 from django.db import connection, transaction
 
 logger = logging.getLogger(__name__)
+
+
+def _student_programme_q(programme_type):
+    scope = (programme_type or '').strip().upper()
+    names = PROGRAMME_NAMES_BY_SCOPE.get(scope)
+    if names:
+        return (
+            Q(batch_id__curriculum__programme__category=scope)
+            | Q(programme__in=names)
+        )
+    return Q(programme=programme_type)
+
+
+def _student_programme_sql(programme_type):
+    scope = (programme_type or '').strip().upper()
+    names = PROGRAMME_NAMES_BY_SCOPE.get(scope)
+    if names:
+        return (
+            " AND (p.category = %s OR s.programme IN %s)",
+            [scope, tuple(names)],
+        )
+    return " AND s.programme = %s", [programme_type]
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
@@ -746,6 +769,8 @@ def generate_xlsheet_api(request):
             INNER JOIN auth_user u ON ei.user_id = u.id
             LEFT JOIN academic_information_student s ON ei.id = s.id_id
             LEFT JOIN programme_curriculum_batch b ON s.batch_id_id = b.id
+            LEFT JOIN programme_curriculum_curriculum cur ON b.curriculum_id = cur.id
+            LEFT JOIN programme_curriculum_programme p ON cur.programme_id = p.id
             LEFT JOIN programme_curriculum_discipline d ON b.discipline_id = d.id
             INNER JOIN programme_curriculum_course c ON cr.course_id_id = c.id
             LEFT JOIN programme_curriculum_courseinstructor ci ON cr.course_instructor_id = ci.id
@@ -766,15 +791,9 @@ def generate_xlsheet_api(request):
             
             # Add programme_type filter if specified
             if programme_type:
-                if programme_type.upper() == 'UG':
-                    sql += " AND s.programme IN ('B.Tech', 'B.Des')"
-                elif programme_type.upper() == 'PG':
-                    sql += " AND s.programme IN ('M.Tech', 'M.Des')"
-                elif programme_type.upper() == 'PHD':
-                    sql += " AND s.programme = 'PhD'"
-                else:
-                    sql += " AND s.programme = %s"
-                    params.append(programme_type)
+                programme_sql, programme_params = _student_programme_sql(programme_type)
+                sql += programme_sql
+                params.extend(programme_params)
 
             # Section = the course offering's section (course_instructor), else home section.
             if section:
@@ -1391,19 +1410,10 @@ def available_courses(request):
     regs = course_registration.objects.filter(session=year, semester_type=sem)
 
     if programme_type:
-        programme_mapping = {
-            'UG': ['B.Tech', 'B.Des'],
-            'PG': ['M.Tech', 'M.Des', 'PhD']
-        }
-        
-        if programme_type in programme_mapping:
-            programmes = programme_mapping[programme_type]
-            from applications.academic_information.models import Student
-            student_ids_with_programme = Student.objects.filter(
-                programme__in=programmes
-            ).values_list('id', flat=True)
-            
-            regs = regs.filter(student_id__in=student_ids_with_programme)
+        student_ids_with_programme = Student.objects.filter(
+            _student_programme_q(programme_type)
+        ).values_list('id', flat=True)
+        regs = regs.filter(student_id__in=student_ids_with_programme)
     
     course_ids = regs.values_list('course_id', flat=True).distinct()
     courses = Courses.objects.filter(id__in=course_ids)
@@ -1467,10 +1477,10 @@ def export_all_courses_zip(request):
     # Build base query for course_registration
     regs = course_registration.objects.filter(session=academic_year, semester_type=semester_type)
     if programme_type:
-        prog_map = {'UG': ['B.Tech', 'B.Des'], 'PG': ['M.Tech', 'M.Des', 'PhD']}
-        if programme_type.upper() in prog_map:
-            stu_ids = Student.objects.filter(programme__in=prog_map[programme_type.upper()]).values_list('id', flat=True)
-            regs = regs.filter(student_id__in=stu_ids)
+        stu_ids = Student.objects.filter(
+            _student_programme_q(programme_type)
+        ).values_list('id', flat=True)
+        regs = regs.filter(student_id__in=stu_ids)
 
     course_ids = regs.values_list('course_id', flat=True).distinct()
     courses = Courses.objects.filter(id__in=course_ids).order_by('code')
@@ -1514,6 +1524,8 @@ def export_all_courses_zip(request):
                 INNER JOIN auth_user u ON ei.user_id = u.id
                 LEFT JOIN academic_information_student s ON ei.id = s.id_id
                 LEFT JOIN programme_curriculum_batch b ON s.batch_id_id = b.id
+                LEFT JOIN programme_curriculum_curriculum cur ON b.curriculum_id = cur.id
+                LEFT JOIN programme_curriculum_programme p ON cur.programme_id = p.id
                 LEFT JOIN programme_curriculum_discipline d ON b.discipline_id = d.id
                 LEFT JOIN programme_curriculum_courseinstructor ci ON cr.course_instructor_id = ci.id
                 WHERE cr.session = %s AND cr.semester_type = %s AND cr.course_id_id = %s
@@ -1528,11 +1540,9 @@ def export_all_courses_zip(request):
                     params.append(list_type)
 
             if programme_type:
-                pt = programme_type.upper()
-                if pt == 'UG':
-                    sql += " AND s.programme IN ('B.Tech', 'B.Des')"
-                elif pt == 'PG':
-                    sql += " AND s.programme IN ('M.Tech', 'M.Des', 'PhD')"
+                programme_sql, programme_params = _student_programme_sql(programme_type)
+                sql += programme_sql
+                params.extend(programme_params)
 
             sql += ' ORDER BY u.username'
 

--- a/FusionIIIT/applications/academic_information/migrations/0010_normalize_phd_programme.py
+++ b/FusionIIIT/applications/academic_information/migrations/0010_normalize_phd_programme.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+
+def normalize_phd_programme(apps, schema_editor):
+    Student = apps.get_model('academic_information', 'Student')
+    Student.objects.filter(
+        programme__in=('Ph.D', 'Ph.D.', 'PHD', 'phd')
+    ).update(programme='PhD')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('academic_information', '0009_alphanumeric_sections'),
+    ]
+
+    operations = [
+        migrations.RunPython(normalize_phd_programme, migrations.RunPython.noop),
+    ]

--- a/FusionIIIT/applications/academic_information/tests.py
+++ b/FusionIIIT/applications/academic_information/tests.py
@@ -2,7 +2,9 @@ import json
 from types import SimpleNamespace
 
 from django.contrib.auth.models import User
-from django.test import TestCase
+from django.test import Client, TestCase
+from django.utils import timezone
+from rest_framework.authtoken.models import Token
 
 from applications.academic_information.models import Student
 from applications.academic_information.utils import (
@@ -11,7 +13,9 @@ from applications.academic_information.utils import (
 from applications.academic_procedures.models import (
     FinalRegistration, InitialRegistration, course_registration,
 )
-from applications.globals.models import ExtraInfo, Faculty
+from applications.globals.models import (
+    Designation, ExtraInfo, Faculty, HoldsDesignation,
+)
 from applications.programme_curriculum.models import (
     Batch, Course, CourseInstructor, CourseSlot, Curriculum, Discipline,
     Programme, Semester,
@@ -196,3 +200,78 @@ class AllocationPublicationTests(TestCase):
         self.assertTrue(FinalRegistration.objects.filter(
             student_id=second_student).exists())
         self.assertEqual(FinalRegistration.objects.count(), 2)
+
+
+class PhdStudentListTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        admin = User.objects.create_user(username='roll_list_admin')
+        token = Token.objects.create(user=admin)
+        designation = Designation.objects.create(name='acadadmin')
+        HoldsDesignation.objects.create(
+            user=admin,
+            working=admin,
+            designation=designation,
+            held_at=timezone.now(),
+        )
+        self.auth = 'Token {}'.format(token.key)
+
+        programme = Programme.objects.create(
+            category='PHD', name='Test Ph.D.', programme_begin_year=2026)
+        discipline = Discipline.objects.create(
+            name='Test Doctoral Discipline', acronym='TDD')
+        curriculum = Curriculum.objects.create(
+            programme=programme, name='Test Ph.D. Curriculum',
+            no_of_semester=8)
+        semester = Semester.objects.create(
+            curriculum=curriculum, semester_no=1)
+        canonical_batch = Batch.objects.create(
+            name='PhD (Odd)', discipline=discipline, year=2026,
+            curriculum=curriculum)
+        legacy_batch = Batch.objects.create(
+            name='PhD (Even)', discipline=discipline, year=2026)
+        self.course = Course.objects.create(
+            code='TD8001', name='Doctoral Test Course', credit=4,
+            syllabus='', ref_books='')
+
+        self._register_student(
+            '26TDD001', 'Other', canonical_batch, semester)
+        self._register_student(
+            '26TDD002', 'Ph.D', legacy_batch, semester)
+
+    def _register_student(self, roll_no, programme, batch, semester):
+        user = User.objects.create_user(username=roll_no)
+        extra = ExtraInfo.objects.create(
+            id=roll_no, user=user, user_type='student')
+        student = Student.objects.create(
+            id=extra, programme=programme, batch=2026, batch_id=batch,
+            category='GEN', curr_semester_no=1)
+        course_registration.objects.create(
+            student_id=student,
+            working_year=2026,
+            semester_id=semester,
+            course_id=self.course,
+            registration_type='Regular',
+            session='2026-27',
+            semester_type='Odd Semester',
+        )
+
+    def test_phd_preview_accepts_category_and_legacy_programme_value(self):
+        response = self.client.post(
+            '/aims/api/generatexlsheet',
+            data=json.dumps({
+                'academic_year': '2026-27',
+                'semester_type': 'Odd Semester',
+                'course': self.course.id,
+                'programme_type': 'PHD',
+                'preview_only': True,
+            }),
+            content_type='application/json',
+            HTTP_AUTHORIZATION=self.auth,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            {student['roll_no'] for student in response.json()['students']},
+            {'26TDD001', '26TDD002'},
+        )

--- a/FusionIIIT/applications/examination/api/views.py
+++ b/FusionIIIT/applications/examination/api/views.py
@@ -24,6 +24,7 @@ from applications.globals.programme_scope import (
     scope_via_student,
     scopes_for,
     student_in_scope,
+    programme_display_name,
 )
 from applications.academic_information.models import(Student)
 from applications.online_cms.models import(Student_grades)
@@ -4776,14 +4777,7 @@ def _build_grade_validation_semesters(student):
     except Exception:
         pass
 
-    PROGRAMME_MAP = {
-        "B.Tech": "Bachelor of Technology",
-        "B.Des": "Bachelor of Design",
-        "M.Tech": "Master of Technology",
-        "M.Des": "Master of Design",
-        "PhD": "Doctor of Philosophy",
-    }
-    programme_full = PROGRAMME_MAP.get(student.programme, student.programme or "")
+    programme_full = programme_display_name(student.programme)
 
     discipline_full = ""
     try:
@@ -4856,14 +4850,6 @@ class GradeValidationView(APIView):
                 .order_by("id__user__username")
             )
 
-            PROGRAMME_MAP = {
-                "B.Tech": "Bachelor of Technology",
-                "B.Des": "Bachelor of Design",
-                "M.Tech": "Master of Technology",
-                "M.Des": "Master of Design",
-                "PhD": "Doctor of Philosophy",
-            }
-
             student_list = []
             for s in students:
                 discipline = ""
@@ -4876,7 +4862,7 @@ class GradeValidationView(APIView):
                 student_list.append({
                     "roll_no": s.id.user.username,
                     "name": f"{s.id.user.first_name} {s.id.user.last_name}".strip(),
-                    "programme": PROGRAMME_MAP.get(s.programme, s.programme or ""),
+                    "programme": programme_display_name(s.programme),
                     "discipline": discipline,
                 })
 

--- a/FusionIIIT/applications/globals/programme_scope.py
+++ b/FusionIIIT/applications/globals/programme_scope.py
@@ -25,16 +25,35 @@ ALL_ACAD_ROLES = UNSCOPED_ACAD_ROLES + SCOPED_ACAD_ROLES
 STUDENT_CATEGORY_PATH = "batch_id__curriculum__programme__category"
 
 # Programme names as they are stored on Student.programme and on
-# BatchConfiguration.programme. The PhD promotion flow writes 'Ph.D' while
-# academic_information.Constants declares 'PhD', so both spellings count.
+# BatchConfiguration.programme. Legacy PhD rows use multiple spellings.
 PROGRAMME_NAMES_BY_SCOPE = {
     "UG": ("B.Tech", "B.Des"),
     "PG": ("M.Tech", "M.Des"),
-    "PHD": ("PhD", "Ph.D"),
+    "PHD": ("PhD", "Ph.D", "Ph.D.", "PHD"),
+}
+
+PROGRAMME_DISPLAY_NAMES = {
+    "B.Tech": "Bachelor of Technology",
+    "B.Des": "Bachelor of Design",
+    "M.Tech": "Master of Technology",
+    "M.Des": "Master of Design",
+    "PhD": "Doctor of Philosophy",
 }
 
 # 'ug' / 'pg' / 'phd' as the admission-record models spell it
 ADMISSION_TYPE_BY_SCOPE = {"UG": "ug", "PG": "pg", "PHD": "phd"}
+
+
+def canonical_programme_name(name):
+    value = (name or "").strip()
+    if value.upper().replace(".", "") == "PHD":
+        return "PhD"
+    return value
+
+
+def programme_display_name(name):
+    canonical = canonical_programme_name(name)
+    return PROGRAMME_DISPLAY_NAMES.get(canonical, canonical)
 
 
 def _role_names(user):

--- a/FusionIIIT/applications/globals/tests.py
+++ b/FusionIIIT/applications/globals/tests.py
@@ -1,3 +1,19 @@
-# from django.test import TestCase
+from django.test import SimpleTestCase
 
-# Create your tests here.
+from applications.globals.programme_scope import (
+    canonical_programme_name,
+    programme_display_name,
+)
+
+
+class ProgrammeNameTests(SimpleTestCase):
+    def test_phd_spellings_share_one_internal_value(self):
+        for value in ('PhD', 'Ph.D', 'Ph.D.', 'PHD', 'phd'):
+            self.assertEqual(canonical_programme_name(value), 'PhD')
+
+    def test_phd_display_name_is_stable_for_legacy_values(self):
+        for value in ('PhD', 'Ph.D', 'Ph.D.'):
+            self.assertEqual(
+                programme_display_name(value),
+                'Doctor of Philosophy',
+            )

--- a/FusionIIIT/applications/programme_curriculum/api/views_student_management.py
+++ b/FusionIIIT/applications/programme_curriculum/api/views_student_management.py
@@ -263,6 +263,7 @@ from applications.globals.programme_scope import (
     admission_record_in_scope,
     admission_type_in_scope,
     batch_in_scope,
+    canonical_programme_name,
     programme_name_in_scope,
     scope_admission_records,
     scope_batches,
@@ -2278,12 +2279,13 @@ def update_student_status(request):
                         else:
                             transfer_message_addition += f" | Using batch: {final_batch.name} (no curriculum assigned to batch)"
 
+                        academic_programme_name = canonical_programme_name(programme_name)
                         academic_student, created = AcademicStudent.objects.get_or_create(
                             id=extra_info, 
                             defaults={
                                 'batch_id': final_batch,
                                 'specialization': specialization,
-                                'programme': programme_name,
+                                'programme': academic_programme_name,
                                 'batch': student.year,  
                                 'father_name': student.father_name or '',  
                                 'mother_name': student.mother_name or '', 
@@ -2299,7 +2301,7 @@ def update_student_status(request):
                         if not created:                         
                             academic_student.specialization = specialization
                             academic_student.batch_id = final_batch
-                            academic_student.programme = programme_name 
+                            academic_student.programme = academic_programme_name
                             academic_student.batch = student.year 
                             academic_student.father_name = student.father_name or ''  
                             academic_student.mother_name = student.mother_name or '' 


### PR DESCRIPTION
## Summary
- resolve programme filters from the canonical batch category with legacy student-value fallbacks
- normalize existing PhD programme spellings and canonicalize future student transfers
- keep Grade Validation programme labels consistent across legacy records

## Validation
- 15 related Django tests passed
- migration consistency check passed
- Python compilation passed