### PR TITLE
Require a grade before allotting a course a student already holds

### DIFF
--- a/FusionIIIT/applications/academic_procedures/api/views.py
+++ b/FusionIIIT/applications/academic_procedures/api/views.py
@@ -2384,6 +2384,44 @@ def delete_preregistration(request):
         )
 
 
+def _registration_type_for_allotment(
+        roll_no, student, course, semester, semester_type):
+    previous = course_registration.objects.filter(
+        student_id=student,
+        course_id=course,
+    )
+    if not previous.exists():
+        return 'Regular'
+
+    grade = latest_grade(roll_no, course)
+    if not grade:
+        existing = previous.order_by('-id').first()
+        raise ValueError(
+            f"{roll_no} already holds {course.code} as "
+            f"{existing.semester_type} / {existing.registration_type} and has no grade yet."
+        )
+
+    registration_type = registration_type_for_grade(grade.grade)
+    if registration_type == 'Regular':
+        raise ValueError(
+            f"{roll_no} already completed {course.code} with grade {grade.grade}; "
+            "the course is not eligible for repeat registration."
+        )
+
+    clash = previous.filter(
+        semester_id=semester,
+        semester_type=semester_type,
+        registration_type=registration_type,
+    ).first()
+    if clash:
+        raise ValueError(
+            f"{roll_no} already holds {course.code} in semester "
+            f"{semester.semester_no} as {clash.semester_type} / {clash.registration_type}."
+        )
+
+    return registration_type
+
+
 @api_view(['POST'])
 @authentication_classes([TokenAuthentication])
 @permission_classes([IsAuthenticated])
@@ -2428,6 +2466,7 @@ def allot_courses(request):
             checks, pre_regs, final_regs, course_regs = [], [], [], []
             row_errors = []
             seen = set()
+            queued_registrations = set()
 
             for i in range(1, sheet.nrows):
 
@@ -2453,6 +2492,25 @@ def allot_courses(request):
                         raise ValueError(
                             f"'{code}' is not one of the courses in slot '{slot_name}' "
                             f"(semester {sem_no}); add it to the slot or name the slot that holds it.")
+                    reg_type = _registration_type_for_allotment(
+                        roll_no, student, course, sem, sem_type
+                    )
+                    registration_key = (
+                        student.pk,
+                        course.pk,
+                        sem.pk,
+                        sem_type,
+                        reg_type,
+                    )
+                    if registration_key in queued_registrations:
+                        raise ValueError(
+                            f"Duplicate row for {roll_no} and {code} in this upload."
+                        )
+
+                    offering = resolve_offering(
+                        student, course, working_year, sem_type
+                    )
+                    queued_registrations.add(registration_key)
                     if roll_no not in seen:
                         checks.append(StudentRegistrationChecks(
                             student_id=student,
@@ -2467,35 +2525,17 @@ def allot_courses(request):
                         course_slot_id=slot,
                         course_id=course,
                         semester_id=sem,
-                        priority=1
+                        priority=1,
+                        registration_type=reg_type,
                     ))
                     final_regs.append(FinalRegistration(
                         student_id=student,
                         course_slot_id=slot,
                         course_id=course,
                         semester_id=sem,
-                        verified=True
+                        verified=True,
+                        registration_type=reg_type,
                     ))
-                    # A repeat within the same term has to say which kind of
-                    # repeat it is, or it collides with the original; the grade
-                    # on record decides that. Across terms the term itself
-                    # already separates the rows.
-                    held = course_registration.objects.filter(
-                        student_id=student, course_id=course, semester_id=sem,
-                        semester_type=sem_type)
-                    reg_type = 'Regular'
-                    if held.exists():
-                        sg = latest_grade(roll_no, course)
-                        reg_type = registration_type_for_grade(sg.grade) if sg else 'Regular'
-                        clash = held.filter(registration_type=reg_type).first()
-                        if clash:
-                            raise ValueError(
-                                f"{roll_no} already holds {code} in semester {sem_no} as "
-                                f"{clash.semester_type} / {clash.registration_type}"
-                                + (f", and has no grade in it yet, so this repeat has no type to take."
-                                   if not sg else "."))
-
-                    offering = resolve_offering(student, course, working_year, sem_type)
                     course_regs.append(course_registration(
                         session=academic_year,
                         working_year = working_year,

--- a/FusionIIIT/applications/academic_procedures/test_allot_course_repeats.py
+++ b/FusionIIIT/applications/academic_procedures/test_allot_course_repeats.py
@@ -1,0 +1,219 @@
+from io import BytesIO
+
+import xlwt
+from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+
+from applications.academic_information.models import Student
+from applications.academic_procedures.models import (
+    FinalRegistration,
+    InitialRegistration,
+    StudentRegistrationChecks,
+    course_registration,
+)
+from applications.globals.models import Designation, ExtraInfo, HoldsDesignation
+from applications.online_cms.models import Student_grades
+from applications.programme_curriculum.models import (
+    Batch,
+    Course,
+    CourseSlot,
+    Curriculum,
+    Discipline,
+    Programme,
+    Semester,
+)
+
+
+class AllotCourseRepeatTests(TestCase):
+    def setUp(self):
+        programme = Programme.objects.create(
+            category='UG',
+            name='Bachelor of Technology',
+            programme_begin_year=2024,
+        )
+        discipline = Discipline.objects.create(
+            name='Mechanical Engineering',
+            acronym='ME',
+        )
+        curriculum = Curriculum.objects.create(
+            programme=programme,
+            name='B.Tech 2024',
+            no_of_semester=8,
+        )
+        self.semester = Semester.objects.create(
+            curriculum=curriculum,
+            semester_no=4,
+        )
+        self.batch = Batch.objects.create(
+            name='B.Tech',
+            discipline=discipline,
+            year=2024,
+            curriculum=curriculum,
+        )
+        self.course = Course.objects.create(
+            code='PR2002',
+            name='Discipline Project',
+            credit=2,
+            syllabus='',
+            ref_books='',
+        )
+        self.slot = CourseSlot.objects.create(
+            semester=self.semester,
+            name='PR',
+            type='Project',
+        )
+        self.slot.courses.add(self.course)
+
+        student_user = User.objects.create_user(username='24BME054')
+        student_extra = ExtraInfo.objects.create(
+            id='24BME054',
+            user=student_user,
+            user_type='student',
+            user_status='PRESENT',
+        )
+        self.student = Student.objects.create(
+            id=student_extra,
+            programme='B.Tech',
+            batch=2024,
+            batch_id=self.batch,
+            category='GEN',
+            curr_semester_no=4,
+        )
+
+        admin = User.objects.create_user(username='academic-admin')
+        designation = Designation.objects.create(name='acadadmin')
+        HoldsDesignation.objects.create(
+            user=admin,
+            working=admin,
+            designation=designation,
+        )
+        token = Token.objects.create(user=admin)
+        self.client = APIClient()
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {token.key}')
+
+    def create_previous_registration(self):
+        return course_registration.objects.create(
+            student_id=self.student,
+            semester_id=self.semester,
+            course_id=self.course,
+            course_slot_id=self.slot,
+            registration_type='Regular',
+            semester_type='Even Semester',
+            session='2025-26',
+        )
+
+    def create_grade(self, grade):
+        return Student_grades.objects.create(
+            course_id=self.course,
+            semester=4,
+            year=2026,
+            roll_no=self.student.pk,
+            grade=grade,
+            batch=2024,
+            academic_year='2025-26',
+            semester_type='Even Semester',
+            verified=True,
+        )
+
+    def upload(self, rows):
+        workbook = xlwt.Workbook()
+        sheet = workbook.add_sheet('Courses')
+        for column, value in enumerate(('Roll Number', 'Slot', 'Course Code')):
+            sheet.write(0, column, value)
+        for row_number, row in enumerate(rows, start=1):
+            for column, value in enumerate(row):
+                sheet.write(row_number, column, value)
+        content = BytesIO()
+        workbook.save(content)
+        uploaded = SimpleUploadedFile(
+            'allotment.xls',
+            content.getvalue(),
+            content_type='application/vnd.ms-excel',
+        )
+        return self.client.post(
+            '/academic-procedures/api/acad/allot_courses',
+            {
+                'batch': str(self.batch.pk),
+                'semester': '4',
+                'semester_type': 'Summer Semester',
+                'academic_year': '2025-26',
+                'allotedCourses': uploaded,
+            },
+            format='multipart',
+        )
+
+    def test_cross_term_repeat_without_grade_is_rejected(self):
+        self.create_previous_registration()
+
+        response = self.upload([('24BME054', 'PR', 'PR2002')])
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(course_registration.objects.count(), 1)
+        self.assertFalse(InitialRegistration.objects.exists())
+        self.assertFalse(FinalRegistration.objects.exists())
+        self.assertFalse(StudentRegistrationChecks.objects.exists())
+        self.assertIn('has no grade yet', response.data['reasons'][0])
+
+    def test_failed_cross_term_repeat_becomes_backlog(self):
+        self.create_previous_registration()
+        self.create_grade('F')
+
+        response = self.upload([('24BME054', 'PR', 'PR2002')])
+
+        self.assertEqual(response.status_code, 200)
+        summer = course_registration.objects.get(semester_type='Summer Semester')
+        self.assertEqual(summer.registration_type, 'Backlog')
+        self.assertEqual(
+            InitialRegistration.objects.get().registration_type,
+            'Backlog',
+        )
+        self.assertEqual(
+            FinalRegistration.objects.get().registration_type,
+            'Backlog',
+        )
+
+    def test_low_grade_cross_term_repeat_becomes_improvement(self):
+        self.create_previous_registration()
+        self.create_grade('C')
+
+        response = self.upload([('24BME054', 'PR', 'PR2002')])
+
+        self.assertEqual(response.status_code, 200)
+        summer = course_registration.objects.get(semester_type='Summer Semester')
+        self.assertEqual(summer.registration_type, 'Improvement')
+        self.assertEqual(
+            InitialRegistration.objects.get().registration_type,
+            'Improvement',
+        )
+        self.assertEqual(
+            FinalRegistration.objects.get().registration_type,
+            'Improvement',
+        )
+
+    def test_cleared_course_cannot_be_registered_again(self):
+        self.create_previous_registration()
+        self.create_grade('B')
+
+        response = self.upload([('24BME054', 'PR', 'PR2002')])
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(course_registration.objects.count(), 1)
+        self.assertIn('not eligible for repeat', response.data['reasons'][0])
+
+    def test_duplicate_rows_in_one_upload_are_inserted_once(self):
+        response = self.upload([
+            ('24BME054', 'PR', 'PR2002'),
+            ('24BME054', 'PR', 'PR2002'),
+        ])
+
+        self.assertEqual(response.status_code, 207)
+        self.assertEqual(response.data['inserted_rows'], 1)
+        self.assertEqual(response.data['failed_rows_count'], 1)
+        self.assertIn('Duplicate row', response.data['reasons'][0])
+        self.assertEqual(course_registration.objects.count(), 1)
+        self.assertEqual(InitialRegistration.objects.count(), 1)
+        self.assertEqual(FinalRegistration.objects.count(), 1)
+        self.assertEqual(StudentRegistrationChecks.objects.count(), 1)


### PR DESCRIPTION
A summer allotment would register a course the student was still holding from the term it anchors to, with no grade on record. Nothing distinguished the two attempts, and because the pre-registration and final-registration rows carried no type they collided with the original and were dropped, leaving the summer attempt half recorded.

A repeat now has to be justified by the grade on record:

| Grade on record | Outcome |
| --- | --- |
| none | refused, naming the registration already held |
| failing | registered as Backlog |
| below the improvement threshold | registered as Improvement |
| already cleared | refused as not eligible for repeat |

The derived type is written to `InitialRegistration` and `FinalRegistration` too, so all three rows describe the same attempt. Two identical rows in one upload are now reported as a duplicate and inserted once, rather than quietly collapsing into one.

`test_allot_course_repeats.py` covers the five cases. Note that the backend test database cannot be built in this checkout — a `RunSQL` step in the migration history references `course_registration` before it is created, which is pre-existing and unrelated to this change — so each case was additionally exercised against a restored copy of the live database inside rolled-back transactions, and all five match the assertions: refusal without a grade, Backlog on a failing grade, Improvement on a low grade, refusal for a cleared course, and 207 with one row inserted and one duplicate reported.

This is deliberately stricter than before: an allotment for a course a student is currently registered for, with results not yet announced, is now refused instead of accepted.