### PR TITLE
Capitalise the salutation on the bonafide certificate

### DIFF
--- a/FusionIIIT/applications/academic_procedures/api/bonafide_certificate.py
+++ b/FusionIIIT/applications/academic_procedures/api/bonafide_certificate.py
@@ -117,7 +117,7 @@ def build_certificate_context(student):
         'name': name,
         'roll_number': student.id.user.username,
         'gender': 'Female' if is_female else 'Male' if gender == 'M' else '',
-        'salutation': 'Ms.' if is_female else 'Mr.' if gender == 'M' else '',
+        'salutation': 'MS.' if is_female else 'MR.' if gender == 'M' else '',
         'relation': 'D/o' if is_female else 'S/o' if gender == 'M' else '',
         'pronoun': 'her' if is_female else 'his' if gender == 'M' else '',
         'father_name': father_name,
@@ -204,7 +204,7 @@ def render_bonafide_pdf(
         f'<b>{escape(context["salutation"])} {escape(context["name"])}</b> '
         f'(Roll No. {escape(context["roll_number"])}) '
         f'{escape(context["relation"])} '
-        f'<b>Mr. {escape(context["father_name"])}</b> is a student of '
+        f'<b>MR. {escape(context["father_name"])}</b> is a student of '
         f'<b>{escape(context["year_ordinal"])} Year</b> '
         f'({escape(context["semester_ordinal"])} Semester) '
         f'<b>{escape(context["programme"])}</b> in '

--- a/FusionIIIT/applications/academic_procedures/test_bonafide_certificate.py
+++ b/FusionIIIT/applications/academic_procedures/test_bonafide_certificate.py
@@ -70,7 +70,7 @@ class BonafideCertificateTests(TestCase):
         self.assertEqual(response.status_code, 200)
         student = response.data['student']
         self.assertEqual(student['name'], 'Ananya Priyadarshini Venkateshwarlu')
-        self.assertEqual(student['salutation'], 'Ms.')
+        self.assertEqual(student['salutation'], 'MS.')
         self.assertEqual(student['relation'], 'D/o')
         self.assertEqual(student['father_name'], 'Rajesh Venkateshwarlu')
         self.assertEqual(student['year_ordinal'], '2nd')
@@ -110,7 +110,7 @@ class BonafideCertificateTests(TestCase):
         self.student.id.sex = 'M'
         context = build_certificate_context(self.student)
 
-        self.assertEqual(context['salutation'], 'Mr.')
+        self.assertEqual(context['salutation'], 'MR.')
         self.assertEqual(context['relation'], 'S/o')
         self.assertEqual(context['pronoun'], 'his')
 
@@ -175,7 +175,7 @@ class BonafideCertificateTests(TestCase):
         self.assertAlmostEqual(float(page.mediaBox.getHeight()), 841.89, places=1)
         text = ' '.join(page.extractText().split())
         self.assertIn('Ananya Priyadarshini Venkateshwarlu', text)
-        self.assertIn('D/o Mr. Rajesh Venkateshwarlu', text)
+        self.assertIn('D/o MR. Rajesh Venkateshwarlu', text)
         self.assertIn('Bachelor of Technology in Computer Science and Engineering', text)
         self.assertIn('2026 to 2030', text)
         self.assertIn(


### PR DESCRIPTION
The bonafide certificate addressed the student as `Mr.` or `Ms.` and the father as `Mr.`, which reads inconsistently beside the rest of the document, where names and headings are set in capitals.

Both are now `MR.` and `MS.`, for either gender and in every place a salutation appears:

- the student's name in `This is to certify that …`
- the student's name again in `This certificate is being issued to …`
- the father's name in the parentage line, which was hardcoded separately from the student's salutation

`D/o` / `S/o` and the `his` / `her` pronoun are unchanged — they are not salutations and are conventionally mixed case. Any `Mr.` / `Shri` / `Sri` already stored on the father's name is still stripped before `MR.` is prepended, so a stored `Mr. …` does not render as `MR. Mr. …`.

Verified by rendering the certificate for a real student of each gender and reading the text back out of the PDF:

| Student | Salutations in the PDF | Relation |
| --- | --- | --- |
| Female | `MS.` x2 (both sentences) + `MR.` x1 (father) | `D/o` |
| Male | `MR.` x3 (student twice, father once) | `S/o` |

No mixed-case `Mr.` or `Ms.` remains in either. The three affected assertions in `test_bonafide_certificate.py` are updated to match; note the backend test database cannot be built in this checkout — a `RunSQL` step in the migration history references `course_registration` before it is created, which is pre-existing — so the PDF render above is the verification. `manage.py check` clean, no migrations.