### PR TITLE
Refresh issued bonafide certificates after the salutation change

### DIFF
--- a/FusionIIIT/applications/academic_procedures/migrations/0055_clear_bonafide_pdf_cache.py
+++ b/FusionIIIT/applications/academic_procedures/migrations/0055_clear_bonafide_pdf_cache.py
@@ -1,0 +1,24 @@
+from django.db import migrations
+
+
+def clear_stored_pdfs(apps, schema_editor):
+    """Drop the cached copies so issued certificates pick up the current wording.
+
+    A stored PDF is served back verbatim, so certificates issued before the
+    salutation was capitalised would keep the old wording for ever. Clearing
+    the cache makes the next download re-render them. Safe here because the
+    feature is days old and no student's year or semester has moved since.
+    """
+    Certificate = apps.get_model('academic_procedures', 'BonafideCertificate')
+    Certificate.objects.exclude(pdf_content=None).update(pdf_content=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('academic_procedures', '0054_merge_20260828_1758'),
+    ]
+
+    operations = [
+        migrations.RunPython(clear_stored_pdfs, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
Follow-up to #1976. Capitalising the salutation only affected certificates generated from then on: an issued certificate keeps a copy of its PDF in `pdf_content`, and `_certificate_pdf()` returns those bytes verbatim, so the ones already generated would have kept `Mr.` / `Ms.` for ever.

This clears the cached copies, so the next download re-renders them from the current code. Reference number and issue date come from the certificate row, so they are preserved.

The caveat, stated plainly: re-rendering rebuilds the body from the student's **current** record, so a certificate issued long enough ago that the student has since moved year or semester would come back showing the newer details. That is not a problem today — the feature is days old, the three certificates in existence were issued between 27 August and 2 September, and each student's year and semester still match what their certificate shows. It is not a step to repeat casually later.

Verified after applying the migration: no certificate still holds a cached PDF, and re-rendering each one gives an uppercase salutation throughout, with no mixed-case `Mr.` or `Ms.` remaining.

| Certificate | Salutations on re-render |
| --- | --- |
| male student, education loan | `MR.` x3 |
| female student, scholarship | `MS.` x2 + `MR.` x1 (father) |
| male student, scholarship | `MR.` x3 |

`manage.py check` clean, no model changes detected.