### PR TITLE
Enlarge the type on the bonafide certificate

### DIFF
--- a/FusionIIIT/applications/academic_procedures/api/bonafide_certificate.py
+++ b/FusionIIIT/applications/academic_procedures/api/bonafide_certificate.py
@@ -153,27 +153,27 @@ def render_bonafide_pdf(
         author=settings.BONAFIDE_INSTITUTE_NAME,
     )
     header_style = ParagraphStyle(
-        'Header', fontName='Helvetica-Bold', fontSize=11.5,
-        leading=15, alignment=TA_LEFT,
+        'Header', fontName='Helvetica-Bold', fontSize=13.5,
+        leading=18, alignment=TA_LEFT,
     )
     header_right_style = ParagraphStyle(
         'HeaderRight', parent=header_style, alignment=TA_RIGHT,
     )
     heading_style = ParagraphStyle(
-        'Heading', fontName='Helvetica-Bold', fontSize=13,
-        leading=16, alignment=TA_CENTER,
+        'Heading', fontName='Helvetica-Bold', fontSize=15,
+        leading=19, alignment=TA_CENTER,
     )
     body_style = ParagraphStyle(
-        'Body', fontName='Helvetica', fontSize=11.5,
-        leading=18, alignment=TA_JUSTIFY,
+        'Body', fontName='Helvetica', fontSize=13.5,
+        leading=22, alignment=TA_JUSTIFY,
     )
     signature_style = ParagraphStyle(
-        'Signature', fontName='Helvetica-Bold', fontSize=11.5,
-        leading=15, alignment=TA_LEFT,
+        'Signature', fontName='Helvetica-Bold', fontSize=13.5,
+        leading=18, alignment=TA_LEFT,
     )
     note_style = ParagraphStyle(
-        'Note', fontName='Helvetica', fontSize=11.5,
-        leading=18, alignment=TA_JUSTIFY,
+        'Note', fontName='Helvetica', fontSize=13.5,
+        leading=22, alignment=TA_JUSTIFY,
     )
 
     header = Table(


### PR DESCRIPTION
The certificate was set in 11.5pt, which reads small for a document that is printed and handed to a student.

| | Before | After |
| --- | --- | --- |
| Body paragraphs | 11.5pt, leading 18 | **13.5pt, leading 22** |
| Heading | 13pt, leading 16 | **15pt, leading 19** |
| Header and signature | 11.5pt, leading 15 | **13.5pt, leading 18** |
| Internship note | 11.5pt, leading 18 | **13.5pt, leading 22** |

The line spacing is raised alongside the type rather than left alone, so the larger size does not close up the gap between lines — body leading lands at roughly 1.6 times the font size. Page margins are unchanged.

Checked the case most likely to overflow: the longest father's name in the data (41 characters) together with the Internship purpose, which adds the extra note paragraph. Both render on a single page, as does the ordinary case. `manage.py check` clean, no model changes, no migration.

Certificates that already hold a cached PDF keep their existing layout, since a stored copy is served back verbatim.