### PR TITLE
Raise the ordinal suffix on the bonafide certificate

### DIFF
--- a/FusionIIIT/applications/academic_procedures/api/bonafide_certificate.py
+++ b/FusionIIIT/applications/academic_procedures/api/bonafide_certificate.py
@@ -50,6 +50,14 @@ def _father_name(value):
     return re.sub(r'^(mr\.?|shri|sri)\s+', '', (value or '').strip(), flags=re.IGNORECASE)
 
 
+def superscript_ordinal(value):
+    """Render '4th' as 4 with the suffix raised, for reportlab markup."""
+    match = re.fullmatch(r'(\d+)(st|nd|rd|th)', (value or '').strip())
+    if not match:
+        return escape(value or '')
+    return f'{match.group(1)}<super>{escape(match.group(2))}</super>'
+
+
 def _programme_duration(student):
     batch = student.batch_id
     category = ''
@@ -205,8 +213,8 @@ def render_bonafide_pdf(
         f'(Roll No. {escape(context["roll_number"])}) '
         f'{escape(context["relation"])} '
         f'<b>MR. {escape(context["father_name"])}</b> is a student of '
-        f'<b>{escape(context["year_ordinal"])} Year</b> '
-        f'({escape(context["semester_ordinal"])} Semester) '
+        f'<b>{superscript_ordinal(context["year_ordinal"])} Year</b> '
+        f'({superscript_ordinal(context["semester_ordinal"])} Semester) '
         f'<b>{escape(context["programme"])}</b> in '
         f'<b>{escape(context["discipline"])}</b> '
         f'({escape(context["duration_text"])} course duration: '


### PR DESCRIPTION
The certificate read `4th Year (7th Semester)` with the suffix on the baseline, where the convention on a printed certificate is to set it as a superscript.

`superscript_ordinal()` splits an ordinal into its digits and suffix and wraps the suffix in reportlab's `<super>` tag. Anything that is not a plain ordinal falls through to the previous escaped output, so an empty or unexpected value cannot inject markup — the suffix itself is escaped as well.

The value stored on the context is unchanged, so the API still returns `4th` to any other caller; only the PDF rendering is marked up.

Verified in the generated PDF's content stream, which is where a superscript is actually visible — text extraction flattens it:

```
(4) Tj  /F2 11.5 Tf  6.75 Ts  (th)
```

The digit prints at the body size, the suffix smaller and raised 6.75pt above the baseline; the same happens for the semester. No markup leaks into the text, and the certificate still fits one page.

Helper output across the cases: `1st`, `2nd`, `3rd`, `4th`, `11th` all split correctly, and empty or `None` returns an empty string.

`manage.py check` clean, no migration.