### PR TITLE
Give each faculty member their own section's students

### DIFF
--- a/FusionIIIT/applications/academic_information/api/views.py
+++ b/FusionIIIT/applications/academic_information/api/views.py
@@ -1434,16 +1434,26 @@ def available_courses(request):
         year_int = int(year_parts[0])  # Odd/Summer semester is in first year (e.g., 2025 for 2025-26)
     
     for c in courses:
-        instructor_name = "TBA"
-        course_instructor = CourseInstructor.objects.filter(course_id=c, year=year_int, semester_type=sem).first()
-        if course_instructor:
-            instructor_name = f"{course_instructor.instructor_id.id.user.first_name} {course_instructor.instructor_id.id.user.last_name}".strip()
+        # A course can be taught by several faculty, one offering per section,
+        # so report them per section instead of picking whichever comes first.
+        instructors_by_section = {}
+        names = []
+        for off in CourseInstructor.objects.filter(
+                course_id=c, year=year_int, semester_type=sem
+        ).select_related('instructor_id__id__user'):
+            user = off.instructor_id.id.user
+            name = f"{user.first_name} {user.last_name}".strip() or str(off.instructor_id_id)
+            if off.section_label:
+                instructors_by_section.setdefault(off.section_label, name)
+            if name not in names:
+                names.append(name)
 
         data.append({
             "id": c.id,
             "code": c.code,
             "name": c.name,
-            "instructor": instructor_name,
+            "instructor": ", ".join(names) if names else "TBA",
+            "instructors_by_section": instructors_by_section,
             "sections": sorted(section_map.get(c.id, set())),
         })
     return Response(data)
@@ -1551,11 +1561,19 @@ def export_all_courses_zip(request):
                 cols = [c[0] for c in cursor.description]
                 students = [dict(zip(cols, row)) for row in cursor.fetchall()]
 
-            # Instructor
-            instructor_name = 'TBA'
-            ci = CourseInstructor.objects.filter(course_id=course_obj, year=year_int, semester_type=semester_type).first()
-            if ci:
-                instructor_name = f'{ci.instructor_id.id.user.first_name} {ci.instructor_id.id.user.last_name}'.strip()
+            # Instructor. This export covers whole courses rather than one
+            # section, so a course with several offerings names them all.
+            names = []
+            for off in CourseInstructor.objects.filter(
+                    course_id=course_obj, year=year_int, semester_type=semester_type
+            ).select_related('instructor_id__id__user'):
+                user = off.instructor_id.id.user
+                name = f'{user.first_name} {user.last_name}'.strip()
+                if off.section_label:
+                    name = f'{name} ({off.section_label})'
+                if name and name not in names:
+                    names.append(name)
+            instructor_name = ', '.join(names) if names else 'TBA'
 
             # Build workbook
             wb = OpenpyxlWorkbook()

--- a/FusionIIIT/applications/examination/api/views.py
+++ b/FusionIIIT/applications/examination/api/views.py
@@ -2221,6 +2221,56 @@ class UploadGradesProfAPI(APIView):
             )
 
 
+def offering_roll_numbers(offerings, course_id, academic_year, semester_type):
+    """Roll numbers belonging to the given offerings, by the rule grade submission uses."""
+    regs = course_registration.objects.filter(
+        course_id_id=course_id,
+        session=academic_year,
+        semester_type=semester_type,
+    )
+    offering_ids = {o.id for o in offerings}
+    sections = {o.section_label for o in offerings}
+    # A no-section offering owns every registrant; a named section scopes to the
+    # bound offering, falling back to the student's home section for older rows.
+    if sections and None not in sections:
+        regs = regs.filter(
+            Q(course_instructor_id__in=offering_ids)
+            | (Q(course_instructor__isnull=True) & Q(student_id__section__in=sections))
+        )
+    return set(regs.values_list("student_id", flat=True))
+
+
+def resolve_requested_offering(request, course_id, academic_year, semester_type):
+    """The offering a grade sheet was asked for, or (None, None) when unscoped.
+
+    Returns (offerings, error_response).
+    """
+    requested = request.data.get("course_instructor") or request.data.get("course_instructor_id")
+    is_acadadmin = user_holds_role(request.user, "acadadmin")
+    all_offerings = list(CourseInstructor.objects.filter(
+        course_id_id=course_id,
+        year=course_instructor_year(academic_year, semester_type),
+        semester_type=semester_type,
+    ))
+    if requested:
+        chosen = [o for o in all_offerings if str(o.id) == str(requested)]
+        if not chosen:
+            return None, Response({"success": False, "error": "That offering does not exist for this course and term."},
+                                  status=status.HTTP_404_NOT_FOUND)
+        if not is_acadadmin and str(chosen[0].instructor_id_id) != str(request.user.username):
+            return None, Response({"error": "Access denied: that section is taught by another faculty member."},
+                                  status=status.HTTP_403_FORBIDDEN)
+        return chosen, None
+    if is_acadadmin:
+        return None, None
+    mine = [o for o in all_offerings
+            if str(o.instructor_id_id) == str(request.user.username)]
+    if not mine:
+        return None, Response({"error": "Access denied: you are not assigned to teach this course this term."},
+                              status=status.HTTP_403_FORBIDDEN)
+    return mine, None
+
+
 class DownloadGradesAPI(APIView):
     permission_classes = [IsAuthenticated]
 
@@ -2269,10 +2319,42 @@ class DownloadGradesAPI(APIView):
 
                 grades_qs = grades_qs.filter(roll_no__in=student_ids_with_programme)
 
-            course_ids = grades_qs.values_list("course_id_id", flat=True).distinct()
-            courses_details = Courses.objects.filter(id__in=course_ids)
+            course_ids = set(grades_qs.values_list("course_id_id", flat=True).distinct())
+            courses_details = {c.id: c for c in Courses.objects.filter(id__in=course_ids)}
 
-            return Response({"courses": list(courses_details.values())}, status=status.HTTP_200_OK)
+            # One entry per offering, so teaching two sections of a course gives
+            # two downloads rather than one sheet holding both.
+            entries = []
+            for off in CourseInstructor.objects.filter(
+                    instructor_id_id=instructor_id,
+                    year=course_instructor_year(academic_year, semester_type),
+                    semester_type=semester_type,
+                    course_id_id__in=course_ids).order_by("course_id__code", "section_label"):
+                course = courses_details.get(off.course_id_id)
+                if not course:
+                    continue
+                entries.append({
+                    "id": course.id,
+                    "code": course.code,
+                    "name": course.name,
+                    "credit": course.credit,
+                    "version": course.version,
+                    "latest_version": course.latest_version,
+                    "course_instructor_id": off.id,
+                    "section_label": off.section_label,
+                })
+            covered = {e["id"] for e in entries}
+            for course_id_left in course_ids - covered:
+                course = courses_details.get(course_id_left)
+                if course:
+                    entries.append({
+                        "id": course.id, "code": course.code, "name": course.name,
+                        "credit": course.credit, "version": course.version,
+                        "latest_version": course.latest_version,
+                        "course_instructor_id": None, "section_label": None,
+                    })
+
+            return Response({"courses": entries}, status=status.HTTP_200_OK)
 
         except Exception as e:
             # Optionally log the exception here
@@ -2311,6 +2393,19 @@ class GeneratePDFAPI(APIView):
                 semester_type=semester_type
             )
 
+            # Scope to one offering so a course taught by several faculty gives
+            # each of them their own students rather than everybody's.
+            scoped_offerings, offering_error = resolve_requested_offering(
+                request, course_id, academic_year, semester_type)
+            if offering_error:
+                return offering_error
+            if scoped_offerings:
+                rolls = offering_roll_numbers(
+                    scoped_offerings, course_id, academic_year, semester_type)
+                grades = grades.filter(
+                    Q(course_instructor_id__in=[o.id for o in scoped_offerings])
+                    | Q(roll_no__in=rolls))
+
             if programme_type:
                 programme_list, prog_err = resolve_programme_list(programme_type)
                 if prog_err:
@@ -2324,30 +2419,29 @@ class GeneratePDFAPI(APIView):
             
             grades = grades.order_by("roll_no")
 
-            if user_holds_role(request.user, "acadadmin"):
-                ci = CourseInstructor.objects.filter(
-                    course_id_id=course_id,
-                    year=course_instructor_year(academic_year, semester_type),
-                    semester_type=semester_type,
-                )
+            if scoped_offerings:
+                ci_list = list(scoped_offerings)
             else:
-                ci = CourseInstructor.objects.filter(
+                ci_list = list(CourseInstructor.objects.filter(
                     course_id_id=course_id,
                     year=course_instructor_year(academic_year, semester_type),
                     semester_type=semester_type,
-                    instructor_id_id=request.user.username
-                )
-            if not ci.exists():
+                ))
+            if not ci_list:
                 return Response({"success": False, "error": "Course not found."}, status=404)
 
-            # semester   = ci.first().semester_no
-            if user_holds_role(request.user, "acadadmin"):
-                _User = get_user_model()
-                ci_obj = ci.first()
-                instr_user = _User.objects.filter(username=ci_obj.instructor_id_id).first()
-                instructor = f"{instr_user.first_name} {instr_user.last_name}" if instr_user else str(ci_obj.instructor_id_id)
-            else:
-                instructor = f"{request.user.first_name} {request.user.last_name}"
+            # Name whoever the sheet actually covers; an unscoped sheet spans them all.
+            _User = get_user_model()
+            names = []
+            for off in ci_list:
+                user = _User.objects.filter(username=off.instructor_id_id).first()
+                label = (f"{user.first_name} {user.last_name}".strip()
+                         if user else str(off.instructor_id_id))
+                if off.section_label and len(ci_list) > 1:
+                    label = f"{label} ({off.section_label})"
+                if label not in names:
+                    names.append(label)
+            instructor = ", ".join(names)
 
             # count grades
             all_grades   = ["O","A+","A","B+","B","C+","C","D+","D","F","S","X","CD"]
@@ -3835,6 +3929,7 @@ class GradeStatusAPI(APIView):
                             "course_code": course.code,
                             "course_name": course.name,
                             "course_id": course.id,
+                            "course_instructor_id": off.id,
                             "section_label": off.section_label or "—",
                             "professor_name": professor_name,
                             "submitted": "Submitted" if is_sub else "Not Submitted",


### PR DESCRIPTION
A course taught by several faculty — one `CourseInstructor` offering per section — was being collapsed to whichever offering came back first. Three places were affected.

**Grade sheets.** `GeneratePDFAPI` looked up the requesting instructor's offering to decide access, then queried grades by course code alone. So every professor teaching a course received all of its students, and the acadadmin sheet printed `ci.first()`'s name over everybody's grades. For one course this session that was a single 18-page sheet covering 542 students from five sections.

Grades are now scoped to one offering. Only 541 of 105,009 grade rows carry an offering reference, so filtering on that alone would return almost nothing; instead the roster is derived from the registrations using the **same rule grade submission already uses** — bound to the offering, falling back to the student's home section for rows predating sectioning. A professor therefore downloads exactly the roster they were shown when submitting. Requesting an offering taught by someone else is refused; the acadadmin may request any, and an unscoped sheet names every instructor with their section instead of one of them.

**The prof course list** returns one entry per offering, so teaching two sections gives two downloads rather than one sheet holding both.

**The student list and bulk export.** `available_courses` picked the instructor with `.first()`, so every section showed section A's faculty. It now returns instructors per section. The whole-course zip export has no section filter, so each sheet names every offering with its section rather than attributing the course to one person. The single-course Excel download was already correct and is unchanged.

Verified against a restored copy of the live database.

```
PR2002, five offerings:
  section A  153 students   6 pages   DR. AKSHAY PANDEY
  section B  147            6         DR. AKSHAY PANDEY
  section C  137            5         DR. AMIT VISHWAKARMA
  section D   55            3         DR. MANU SRIVASTAVA
  section F   50            2         DR. MANU SRIVASTAVA
                            18 pages combined, as before, when unscoped

as a professor teaching only section C:  C -> 200, D -> 403, A -> 403
as a professor teaching D and F:         two list entries, D -> 200, C -> 403
NS1002 section B -> DR. YASHPAL SINGH KATHARRIA  (was section A's faculty)
```

The scoping does not depend on the caller passing `programme_type`; it keys on whether the offerings carry section labels, since a sectioned offering is by definition undergraduate. Terms whose offerings have no section labels cannot be split and stay combined.

A professor on the current client, sending no offering, now receives only their own students — so this closes the exposure on its own, before the paired client change. `manage.py check` clean, no migration.