### PR TITLE
Carry the previous semester's CPI on the registration receipt

### DIFF
--- a/FusionIIIT/applications/academic_procedures/views.py
+++ b/FusionIIIT/applications/academic_procedures/views.py
@@ -3402,13 +3402,28 @@ def generate_course_registration_receipt(request):
                 'credits': course.course_id.credit
             })
         
+        # CPI as of the previous semester, from the same helper the transcript uses.
+        prev_sem = (current_user.curr_semester_no or 0) - 1
+        prev_sem_cpi = None
+        if prev_sem >= 1:
+            from applications.examination.api.views import calculate_cpi_for_student
+            cpi, _, _ = calculate_cpi_for_student(
+                current_user, prev_sem,
+                'Odd Semester' if prev_sem % 2 else 'Even Semester')
+            if cpi is not None:
+                # One decimal, as calculate_cpi_for_student rounds it and the
+                # transcript prints it.
+                prev_sem_cpi = f'{cpi:.1f}'
+
         context = {
             'current_courseregistrations': course_list,
             'semester_no': current_user.curr_semester_no,
             'name': request.user.first_name + request.user.last_name,
             'roll_no' : current_user.id_id,
             'batch': batch.name+' '+str(batch.year),
-            'branch': curr_id.name.split(' ')[0]
+            'branch': curr_id.name.split(' ')[0],
+            'prev_semester_no': prev_sem if prev_sem >= 1 else None,
+            'prev_sem_cpi': prev_sem_cpi,
         }
         return JsonResponse(context)
     


### PR DESCRIPTION
The course registration receipt is signed by the student and the office, and the CPI it is read against had to be looked up separately. `course_reg_receipt` now returns it alongside the rest of the receipt data.

The figure comes from `calculate_cpi_for_student`, the helper the transcript uses, for the semester before the one being registered — so there is no second definition of the CPI to drift out of step. It is formatted to **one** decimal, as that helper rounds it (`round_from_last_decimal` quantizes to `0.1`) and as the transcript prints it.

Reading the stored `Student.cpi` column would not have worked: it is `0.0` for these students.

A first-semester student has no previous semester, so `prev_sem_cpi` is null and the client prints a dash rather than a misleading zero.

Verified against a restored copy of the live database:

```
25BEC036  semester 3 -> previous semester 2, CPI 8.4   (helper: Decimal('8.4'), tu 34)
23BCS265  semester 7 -> previous semester 6, CPI 6.5   (helper: Decimal('6.5'), tu 122)
```

`manage.py check` clean, no migration.
