### PR TITLE
Correct the previous-semester CPI and the credit summary

### DIFF
--- a/FusionIIIT/applications/academic_procedures/api/urls.py
+++ b/FusionIIIT/applications/academic_procedures/api/urls.py
@@ -1,9 +1,14 @@
 from django.conf.urls import url
 from . import views
 from . import bonafide_certificate
+from .. import views as procedures_views
 
 
 urlpatterns = [
+    # Also reachable here because only /api/ paths are proxied to Django in
+    # production; the bare path returns the client's index.html instead.
+    url(r'^course_reg_receipt/$', procedures_views.generate_course_registration_receipt,
+        name='course_reg_receipt_api'),
     url(r'^acad/bonafide/student/$', bonafide_certificate.bonafide_student,
         name='bonafide-student'),
     url(r'^acad/bonafide/pdf/$', bonafide_certificate.generate_bonafide_pdf,

--- a/FusionIIIT/applications/academic_procedures/api/views.py
+++ b/FusionIIIT/applications/academic_procedures/api/views.py
@@ -1285,6 +1285,9 @@ def verify_course(request):
         "firstname": user_obj.first_name or "",
         "lastname": user_obj.last_name or "",
         "programme_category": _student_programme_category(student),
+        "batch": str(student.batch_id.year) if student.batch_id else "",
+        "branch": (student.batch_id.discipline.acronym
+                   if student.batch_id and student.batch_id.discipline else ""),
     }
 
     # current curriculum & semester - handle None batch_id case
@@ -1380,12 +1383,25 @@ def verify_course(request):
     else:
         current_semester_type = "Even Semester"
 
+    # CPI as of the semester before each one on offer, so a receipt printed for
+    # any semester carries the right figure. Same helper as the transcript.
+    from applications.examination.api.views import previous_term_cpi
+    prev_sem_cpi = {}
+    for sem in {d["sem"] for d in details}:
+        try:
+            value = previous_term_cpi(student, sem)
+        except Exception:
+            continue
+        if value is not None:
+            prev_sem_cpi[str(sem)] = value
+
     return Response({
         "details": details,
         "dict2": dict2,
         "course_list": course_list,
         "semester_list": semester_list,
         "courseslot_list": courseslot_list,
+        "prev_sem_cpi": prev_sem_cpi,
         "date": {"year": yearr, "semflag": semflag},
         "current_semester": {
             "semester_no": student.curr_semester_no,

--- a/FusionIIIT/applications/academic_procedures/views.py
+++ b/FusionIIIT/applications/academic_procedures/views.py
@@ -3402,18 +3402,10 @@ def generate_course_registration_receipt(request):
                 'credits': course.course_id.credit
             })
         
-        # CPI as of the previous semester, from the same helper the transcript uses.
+        # CPI as of the last completed term, summer terms included.
+        from applications.examination.api.views import previous_term_cpi
         prev_sem = (current_user.curr_semester_no or 0) - 1
-        prev_sem_cpi = None
-        if prev_sem >= 1:
-            from applications.examination.api.views import calculate_cpi_for_student
-            cpi, _, _ = calculate_cpi_for_student(
-                current_user, prev_sem,
-                'Odd Semester' if prev_sem % 2 else 'Even Semester')
-            if cpi is not None:
-                # One decimal, as calculate_cpi_for_student rounds it and the
-                # transcript prints it.
-                prev_sem_cpi = f'{cpi:.1f}'
+        prev_sem_cpi = previous_term_cpi(current_user, current_user.curr_semester_no)
 
         context = {
             'current_courseregistrations': course_list,

--- a/FusionIIIT/applications/examination/api/views.py
+++ b/FusionIIIT/applications/examination/api/views.py
@@ -358,6 +358,41 @@ def superseded_course_codes(student, graded_codes):
     return superseded
 
 
+def result_declared_for(student, semester, semester_type):
+    """Whether this student's result for the term has been declared."""
+    ann = ResultAnnouncement.objects.filter(
+        batch=student.batch_id, semester=semester, semester_type=semester_type,
+    ).first()
+    return bool(ann and ann.announced
+                and _is_result_published_for(ann, student.id_id))
+
+
+def previous_term_cpi(student, before_semester):
+    """CPI as of the last term before `before_semester` whose result is declared.
+
+    The term may be a summer one, and calculate_cpi_for_student only counts a
+    summer term when told the term is a summer term -- so the type has to come
+    from the grades rather than from the semester's parity. Terms whose result
+    is not out yet are skipped, so the figure never runs ahead of what the
+    student has been shown.
+    """
+    term_order = {'Odd Semester': 0, 'Even Semester': 1, 'Summer Semester': 2}
+    terms = sorted(
+        {(g['semester'], g['semester_type']) for g in
+         Student_grades.objects
+         .filter(roll_no=student.id_id, semester__lte=(before_semester or 0) - 1)
+         .values('semester', 'semester_type')},
+        key=lambda t: (t[0] or 0, term_order.get(t[1], 0)),
+        reverse=True,
+    )
+    for semester, semester_type in terms:
+        if not result_declared_for(student, semester, semester_type):
+            continue
+        cpi, _, _ = calculate_cpi_for_student(student, semester, semester_type)
+        return f'{cpi:.1f}' if cpi is not None else None
+    return None
+
+
 def calculate_cpi_for_student(student, selected_semester, semester_type, require_announced=False):
     total_unit = Decimal('0')
     if selected_semester % 2 == 0 and semester_type == 'Summer Semester':
@@ -3760,8 +3795,16 @@ class StudentCreditSummaryView(APIView):
             and (sem.get("semester_no"), sem.get("semester_type")) in published
         ]
 
+        # The degree-requirement figure below the table is a UG rule, so the
+        # client needs to know which programme this student is on.
+        try:
+            programme_category = student.batch_id.curriculum.programme.category
+        except AttributeError:
+            programme_category = None
+
         return Response(
-            {"success": True, "semesters": announced},
+            {"success": True, "semesters": announced,
+             "programme_category": programme_category},
             status=status.HTTP_200_OK,
         )
 
@@ -4759,7 +4802,6 @@ def _build_grade_validation_semesters(student):
     course_first_grade = {}
 
     semesters_data = []
-    summer_counter = 0
     cumulative_credits = Decimal('0')  # deduped total (tu), count-once
 
     for key in sorted_keys:
@@ -4767,8 +4809,9 @@ def _build_grade_validation_semesters(student):
         is_summer = _is_summer_key(key)
 
         if is_summer:
-            summer_counter += 1
-            label = f"Summer Semester {summer_counter}"
+            # Named by the semester it follows, as the marksheet names it, not
+            # by how many summer terms the student happens to have taken.
+            label = f"Summer Semester {format_semester_display(s_no, 'Summer Semester').split()[-1]}"
         else:
             label = f"Semester {s_no}"
 


### PR DESCRIPTION
Three faults, found by comparing the registration receipt against the marksheet for the same student.

**The receipt endpoint never reached Django in production.** Only paths containing `/api/` are proxied there; everything else falls through to the client's `index.html`. `course_reg_receipt/` was the one academic-procedures URL without that segment, so the client was parsing an HTML page and every field read off it came back undefined — which is why the CPI showed as a dash. It is now registered under the api prefix too; the old path stays so nothing else that calls it breaks.

```
academic-procedures/api/stu/swayam/availability/   401  application/json
aims/api/available-courses/                        401  application/json
academic-procedures/course_reg_receipt/            200  text/html      <- the SPA
academic-procedures/anything_at_all/               200  text/html      <- confirms the cause
```

**The figure was wrong for a student whose last term was a summer one.** The term type was inferred from the semester's parity, but `calculate_cpi_for_student` only counts a summer term when it is told the term is summer:

```
calculate_cpi_for_student(6, 'Even Semester')   -> 5.3, 116 credits
calculate_cpi_for_student(6, 'Summer Semester') -> 5.4, 123 credits   <- the marksheet
```

`previous_term_cpi()` now reads the last term that actually has grades, takes the type from those grades, and **skips terms whose result has not been declared** — using the same `ResultAnnouncement.announced` and per-student publication check the student result view uses, so the receipt never shows a CPI the student has not been given. Both the student receipt and the academic-side view use this one helper, and the academic side returns it per semester so a receipt printed for any semester carries the right figure.

Verified by revoking announcements inside a rolled-back transaction:

```
as declared today            5.4   (Summer 3)
Summer 3 un-announced        5.3   falls back to semester 6 Even
sem 6 Even also un-announced 4.9   falls back to semester 5 Odd
nothing declared             None  the client prints a dash
```

**Summer rows in the credit summary were numbered by occurrence.** A student's only summer term always read `Summer Semester 1` however late it fell; the marksheet calls the same term Summer 3. It now uses `format_semester_display`, which names a summer term after the semester it follows.

The summary also returns `programme_category`, because the degree-requirement figure below the table encodes undergraduate rules — 148 credits with a six-credit swayam cap — that do not hold for PG or PhD.

The academic-side course view additionally returns `batch` and `branch`, which the receipt header needs and were not previously exposed.

`manage.py check` clean, no migration.