### PR TITLE
Show a student their own Swayam requests again

### DIFF
--- a/FusionIIIT/applications/academic_procedures/api/views.py
+++ b/FusionIIIT/applications/academic_procedures/api/views.py
@@ -4135,9 +4135,12 @@ def student_swayam_requests(request):
         student = Student.objects.get(id=user_details)
 
         request_type = request.GET.get('request_type')
+        academic_year, semester_type = generate_current_session(
+            timezone.now().year, student.curr_semester_no)
         requests_query = SwayamReplacementRequest.objects.filter(
             student=student,
-            semester__semester_no=student.curr_semester_no
+            academic_year=academic_year,
+            semester_type=semester_type,
         )
 
         if request_type:


### PR DESCRIPTION
A student who replaced an elective from an earlier semester saw nothing under **Your Requests**, while the request sat Pending and the academic dashboard listed it.

`student_swayam_requests` filtered on the replaced course's semester:

```python
requests_query = SwayamReplacementRequest.objects.filter(
    student=student,
    semester__semester_no=student.curr_semester_no,
)
```

That `semester` field holds the **source** semester — the one the replaced course was taken in — which the previous-semester path sets to something earlier than the student's current semester. So those rows were excluded by the very filter meant to scope them.

It now scopes by academic year and semester type, taken from the same helper the submit uses, so the filter and the stored values agree by construction.

Only the previous-semester path was affected. A student replacing this semester's Swayam had a source semester equal to their current one by coincidence, so their requests always displayed — which is why this went unnoticed.

Checked on a copy of the production database:

| Student | Rows stored | Returned before | Returned now |
|---|---|---|---|
| current sem 5, source sem 3 | 2 | 0 | 2 |
| current sem 5, source sem 4 | 4 | 0 | 2 |
| current sem 7, source this sem | 4 | 2 | 2 |
| current sem 5, source this sem | 2 | 2 | 2 |

The rows still left out are from an earlier term — two students each carry approved requests from 2025-26 Even Semester, which correctly stay out of the current term's list.